### PR TITLE
Basic link sharing

### DIFF
--- a/packages/magic-shared/package.json
+++ b/packages/magic-shared/package.json
@@ -131,7 +131,8 @@
     "@graph/vue": "workspace:*",
     "@mdi/js": "^7.4.47",
     "@vueuse/core": "catalog:",
-    "ctrl-keys": "^1.0.6"
+    "ctrl-keys": "^1.0.6",
+    "lz-string": "^1.5.0"
   },
   "devDependencies": {
     "nuxt": "^4.1.2",

--- a/packages/magic-shared/src/product/useGraphProduct.ts
+++ b/packages/magic-shared/src/product/useGraphProduct.ts
@@ -1,3 +1,5 @@
+import { onMounted } from 'vue';
+
 import { useComponentSlotsState } from '../component-slot/useComponentSlotsState.ts';
 import { ComponentSlotControls } from '../component-slot/useComponentSlotsState.ts';
 import { Graph } from '../graph/types.ts';
@@ -10,6 +12,7 @@ import {
   AppearanceControls,
   useProductAppearance,
 } from '../ui/appearance/useProductAppearance.ts';
+import { loadGraphFromLinkPayload } from '../ui/link-sharing/linkPayload.ts';
 import { UIControls, UIOptions, useProductUI } from '../ui/useProductUI.ts';
 import { MagicProductManifest } from './manifest.ts';
 import { useLocalStorageGraphSync } from './useLocalStorageGraphSync.ts';
@@ -56,6 +59,10 @@ export const useGraphProduct = (options: GraphProductOptions) => {
 
   if (options.localStorage !== false) {
     useLocalStorageGraphSync(magicGraph);
+  }
+
+  if (magicGraph.magic.ui.linkSharing) {
+    onMounted(() => loadGraphFromLinkPayload(magicGraph));
   }
 
   provideGraph(magicGraph);

--- a/packages/magic-shared/src/ui/bottom-right-controls/BottomRightControls.vue
+++ b/packages/magic-shared/src/ui/bottom-right-controls/BottomRightControls.vue
@@ -10,6 +10,7 @@
   import AnnotationToggle from '../annotations/AnnotationToggle.vue';
   import AppearanceToggle from '../appearance/AppearanceToggle.vue';
   import FullscreenButton from '../fullscreen/FullscreenButton.vue';
+  import LinkSharingButton from '../link-sharing/LinkSharingButton.vue';
 
   const graph = useProvidedGraph();
 </script>
@@ -32,6 +33,7 @@
           />
         </template>
         <VStack class="gap-1 px-1">
+          <LinkSharingButton v-if="graph.magic.ui.linkSharing" />
           <FullscreenButton />
           <div
             class="w-full bg-white opacity-10"

--- a/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
+++ b/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+  import { mdiCheck, mdiLink } from '@mdi/js';
+
+  import { computed, ref } from 'vue';
+
+  import Button from '../../components/button/Button.vue';
+  import Icon from '../../components/icon/Icon.vue';
+  import { useProvidedGraph } from '../../product/useProvidedGraph.ts';
+  import { getLink } from './linkPayload.ts';
+
+  const graph = useProvidedGraph();
+
+  let linkCopiedResetTimer: NodeJS.Timeout;
+
+  // 3 seconds of link copied confirmation state
+  const LINK_COPIED_FEEDBACK_DURATION_MS = 3_000;
+
+  const copyLinkToClipboard = () => {
+    clearTimeout(linkCopiedResetTimer);
+    try {
+      navigator.clipboard.writeText(getLink(graph));
+      linkCopiedToClipboard.value = true;
+      linkCopiedResetTimer = setTimeout(
+        () => (linkCopiedToClipboard.value = false),
+        LINK_COPIED_FEEDBACK_DURATION_MS,
+      );
+    } catch (err) {
+      // TODO handle link copy failure with a toast
+      // https://github.com/Yonava/magic-graphs/issues/783
+      console.error('Failed to copy to clipboard!', err);
+    }
+  };
+
+  const linkCopiedToClipboard = ref(false);
+
+  const display = computed(() => {
+    return linkCopiedToClipboard.value
+      ? {
+          text: 'Link Copied',
+          icon: mdiCheck,
+        }
+      : {
+          text: 'Copy Link',
+          icon: mdiLink,
+        };
+  });
+</script>
+
+<template>
+  <Button
+    class="px-2 bg-transparent w-full justify-start"
+    @click="copyLinkToClipboard"
+  >
+    <template #start>
+      <Icon :path="display.icon" />
+    </template>
+    {{ display.text }}
+  </Button>
+</template>

--- a/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
+++ b/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
@@ -1,0 +1,38 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent,
+} from 'lz-string';
+
+import { MagicGraph } from '../../product/useGraphProduct.ts';
+
+const graphSharePayloadQueryParam = 'graph';
+
+const getLinkPayload = (graph: MagicGraph) => {
+  const encoding = graph.transit.encode();
+  const stringEncoding = JSON.stringify(encoding);
+  return compressToEncodedURIComponent(stringEncoding);
+};
+
+export const getLink = (graph: MagicGraph) => {
+  const { origin } = window.location;
+  const { slug } = graph.magic.manifest.navigation;
+  const payload = getLinkPayload(graph);
+  const graphQueryParam = `${graphSharePayloadQueryParam}=${payload}`;
+
+  return `${origin}/${slug}?${graphQueryParam}`;
+};
+
+export const loadGraphFromLinkPayload = (graph: MagicGraph) => {
+  const url = new URL(window.location.href);
+  const payload = url.searchParams.get(graphSharePayloadQueryParam);
+  if (!payload) return;
+
+  // always consume or else users see stale when they refresh
+  url.searchParams.delete(graphSharePayloadQueryParam);
+  window.history.replaceState({}, '', url);
+
+  const stringEncoding = decompressFromEncodedURIComponent(payload);
+  if (!stringEncoding) return;
+
+  graph.transit.decode(JSON.parse(stringEncoding));
+};

--- a/packages/magic-shared/src/ui/useProductUI.ts
+++ b/packages/magic-shared/src/ui/useProductUI.ts
@@ -16,11 +16,13 @@ export type UIOptions = {
   lensChips?: (graph: Graph) => LensChipDefinition[] | undefined;
   annotations?: boolean;
   debug?: boolean;
+  linkSharing?: boolean;
 };
 
 export type UIControls = {
   lensChips?: LensChipDefinition[];
   annotations?: AnnotationsControls;
+  linkSharing: boolean;
 };
 
 export const useProductUI = (
@@ -71,5 +73,6 @@ export const useProductUI = (
   return {
     annotations,
     lensChips,
+    linkSharing: options.linkSharing !== false,
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       ctrl-keys:
         specifier: ^1.0.6
         version: 1.0.6
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
     devDependencies:
       nuxt:
         specifier: ^4.1.2


### PR DESCRIPTION
Adds a "Copy Link" control that encodes the current graph into a shareable URL, and loads it back on the receiving end.

## How it works

- `linkPayload.ts` — `getLink()` runs `graph.transit.encode()` through `JSON.stringify` + `lz-string`'s `compressToEncodedURIComponent`, producing `{origin}/{slug}?graph={payload}`. `loadGraphFromLinkPayload()` reverses it and calls `graph.transit.decode()`.
- The query param is consumed via `history.replaceState` immediately after read, so a refresh does not re-apply a stale graph.
- `LinkSharingButton.vue` — lives in the bottom-right controls stack, flips to a "Link Copied" check state for 3s after copy.
- Gated by a new `linkSharing` UI option (`useProductUI`), defaulting to on.

## Notes

- Clipboard failure currently only logs; toast handling tracked in #783.
- New dependency: `lz-string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)