### PR TITLE
add canvas performance instrumentation

### DIFF
--- a/packages/canvas-surface/src/events.ts
+++ b/packages/canvas-surface/src/events.ts
@@ -6,11 +6,6 @@ export type CanvasLifecycleEvents = {
   /**
    * triggered at the top and bottom of a repaint, bracketing everything the
    * frame does: the clear, the background pattern and the content draw.
-   *
-   * this exists for measurement. the canvas plugin's own `onBeforeDraw` and
-   * `onDraw` bracket the content draw alone, which leaves out two of the
-   * costlier parts of a frame, so timing built on those would be measuring the
-   * wrong thing
    */
   onBeforeRepaint: () => void;
   onAfterRepaint: () => void;

--- a/packages/canvas-surface/src/events.ts
+++ b/packages/canvas-surface/src/events.ts
@@ -3,6 +3,17 @@ import { EventMapToEventRegistry } from '@graph/primitives/events/types';
 export type CanvasLifecycleEvents = {
   onMounted: () => void;
   onBeforeUnmount: () => void;
+  /**
+   * triggered at the top and bottom of a repaint, bracketing everything the
+   * frame does: the clear, the background pattern and the content draw.
+   *
+   * this exists for measurement. the canvas plugin's own `onBeforeDraw` and
+   * `onDraw` bracket the content draw alone, which leaves out two of the
+   * costlier parts of a frame, so timing built on those would be measuring the
+   * wrong thing
+   */
+  onBeforeRepaint: () => void;
+  onAfterRepaint: () => void;
 };
 
 type CanvasSurfaceLifecycleEventRegistry =
@@ -12,4 +23,6 @@ export const createCanvasLifecycleEventRegistry =
   (): CanvasSurfaceLifecycleEventRegistry => ({
     onMounted: new Set(),
     onBeforeUnmount: new Set(),
+    onBeforeRepaint: new Set(),
+    onAfterRepaint: new Set(),
   });

--- a/packages/canvas-surface/src/index.ts
+++ b/packages/canvas-surface/src/index.ts
@@ -54,10 +54,12 @@ export const useCanvas: UseCanvas = () => {
   const pattern = useBackgroundPattern(camera.state, drawBackgroundPattern);
 
   const repaintCanvas = () => {
+    lifecycleEvents.emit('onBeforeRepaint');
     const ctx = getCtx(canvas);
     camera.transformAndClear(ctx);
     pattern.draw(ctx);
     drawContent.value(ctx);
+    lifecycleEvents.emit('onAfterRepaint');
   };
 
   return {

--- a/packages/graph-dev-tools/src/perf/ctx-counter.ts
+++ b/packages/graph-dev-tools/src/perf/ctx-counter.ts
@@ -1,10 +1,8 @@
 /**
  * Counts what a frame actually asks the canvas to do.
  *
- * For a canvas app this is the highest signal instrument there is. A sampling
- * profiler tells you time went into rendering, which was never in doubt; this
- * turns "feels slow" into "3,400 fillRect and 11 drawImage per frame at 10
- * nodes", which is a claim that can be falsified.
+ * Data that turns "feels slow" into "3,400 fillRect and 11 drawImage per frame at 10
+ * nodes"
  *
  * It patches the prototype rather than wrapping one context, so offscreen
  * canvases are counted too. That matters here: offscreen allocation is the
@@ -14,7 +12,6 @@
  * not a run to read frame timings off of. Measure one at a time.
  */
 
-/** anything with the canvas surface's repaint events. duck typed on purpose */
 export type RepaintEvents = {
   subscribe: (event: 'onBeforeRepaint', callback: () => void) => void;
   unsubscribe: (event: 'onBeforeRepaint', callback: () => void) => void;

--- a/packages/graph-dev-tools/src/perf/ctx-counter.ts
+++ b/packages/graph-dev-tools/src/perf/ctx-counter.ts
@@ -1,0 +1,113 @@
+/**
+ * Counts what a frame actually asks the canvas to do.
+ *
+ * For a canvas app this is the highest signal instrument there is. A sampling
+ * profiler tells you time went into rendering, which was never in doubt; this
+ * turns "feels slow" into "3,400 fillRect and 11 drawImage per frame at 10
+ * nodes", which is a claim that can be falsified.
+ *
+ * It patches the prototype rather than wrapping one context, so offscreen
+ * canvases are counted too. That matters here: offscreen allocation is the
+ * suspected primary cost and it is close to invisible in a sampling profile.
+ *
+ * The patching itself costs something, so a run with the counter attached is
+ * not a run to read frame timings off of. Measure one at a time.
+ */
+
+/** anything with the canvas surface's repaint events. duck typed on purpose */
+export type RepaintEvents = {
+  subscribe: (event: 'onBeforeRepaint', callback: () => void) => void;
+  unsubscribe: (event: 'onBeforeRepaint', callback: () => void) => void;
+};
+
+/** how many canvas elements were created, keyed alongside the ctx call names */
+export const CANVAS_ELEMENTS_CREATED = 'canvasElementsCreated';
+
+export type CtxCounts = Record<string, number>;
+
+export type CtxCounterSnapshot = {
+  frames: number;
+  /** totals since the last reset */
+  total: CtxCounts;
+  /** totals divided by frames, sorted heaviest first */
+  perFrame: CtxCounts;
+};
+
+export type CtxCounter = {
+  snapshot: () => CtxCounterSnapshot;
+  reset: () => void;
+  stop: () => void;
+};
+
+const methodNamesOf = (prototype: object) =>
+  Object.getOwnPropertyNames(prototype).filter((name) => {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+    return typeof descriptor?.value === 'function' && name !== 'constructor';
+  });
+
+export const startCtxCounter = (events?: RepaintEvents): CtxCounter => {
+  const total: CtxCounts = {};
+  let frames = 0;
+
+  const count = (name: string) => {
+    total[name] = (total[name] ?? 0) + 1;
+  };
+
+  const prototype = CanvasRenderingContext2D.prototype;
+  const originalMethods = new Map<string, (...args: unknown[]) => unknown>();
+
+  for (const name of methodNamesOf(prototype)) {
+    const original = (prototype as unknown as Record<string, any>)[name];
+    originalMethods.set(name, original);
+
+    (prototype as unknown as Record<string, any>)[name] = function (
+      this: CanvasRenderingContext2D,
+      ...args: unknown[]
+    ) {
+      count(name);
+      return original.apply(this, args);
+    };
+  }
+
+  const originalCreateElement = document.createElement;
+  document.createElement = function (
+    this: Document,
+    tagName: string,
+    ...rest: unknown[]
+  ) {
+    if (tagName.toLowerCase() === 'canvas') count(CANVAS_ELEMENTS_CREATED);
+    return (originalCreateElement as any).call(this, tagName, ...rest);
+  } as typeof document.createElement;
+
+  const onBeforeRepaint = () => frames++;
+  events?.subscribe('onBeforeRepaint', onBeforeRepaint);
+
+  const snapshot = (): CtxCounterSnapshot => {
+    const perFrame: CtxCounts = {};
+
+    const heaviestFirst = Object.entries(total).sort(
+      ([, a], [, b]) => b - a,
+    ) as [string, number][];
+
+    for (const [name, calls] of heaviestFirst) {
+      perFrame[name] = frames === 0 ? 0 : calls / frames;
+    }
+
+    return { frames, total: { ...total }, perFrame };
+  };
+
+  return {
+    snapshot,
+    reset: () => {
+      for (const name of Object.keys(total)) delete total[name];
+      frames = 0;
+    },
+    stop: () => {
+      for (const [name, original] of originalMethods) {
+        (prototype as unknown as Record<string, any>)[name] = original;
+      }
+      document.createElement = originalCreateElement;
+      events?.unsubscribe('onBeforeRepaint', onBeforeRepaint);
+    },
+  };
+};

--- a/packages/graph-dev-tools/src/perf/frame-timing.ts
+++ b/packages/graph-dev-tools/src/perf/frame-timing.ts
@@ -1,0 +1,144 @@
+/**
+ * Frame timing for the canvas render loop.
+ *
+ * Two numbers, kept apart on purpose, because they answer different questions:
+ *
+ * - interval: the gap between consecutive repaints. answers "are we hitting 60"
+ * - draw: how long the repaint itself takes. answers "why not"
+ *
+ * A run can miss its target with a fast draw (something else is hogging the main
+ * thread) or hit its target with a slow one (nothing else is competing yet), and
+ * a single averaged "fps" hides both cases.
+ */
+import { percentile } from './percentile.ts';
+
+/** anything with the canvas surface's repaint events. duck typed on purpose */
+export type RepaintEvents = {
+  subscribe: (event: RepaintEvent, callback: () => void) => void;
+  unsubscribe: (event: RepaintEvent, callback: () => void) => void;
+};
+
+type RepaintEvent = 'onBeforeRepaint' | 'onAfterRepaint';
+
+export type TimingSummary = {
+  p50: number;
+  p95: number;
+  max: number;
+};
+
+export type FrameTimingStats = {
+  /** repaints recorded since the last reset */
+  frames: number;
+  /** ms between the start of consecutive repaints */
+  interval: TimingSummary;
+  /** ms spent inside the repaint */
+  draw: TimingSummary;
+  /**
+   * repaints whose interval ran past 1.5x the target. a handful during startup
+   * is normal, a steady stream is the symptom being chased
+   */
+  dropped: number;
+  /** frames per second implied by the median interval */
+  fps: number;
+};
+
+const SAMPLE_CAPACITY = 300;
+const DROPPED_FRAME_THRESHOLD = 1.5;
+
+const MARK_START = 'magic-graph:repaint-start';
+const MEASURE_REPAINT = 'magic-graph:repaint';
+
+const summarize = (samples: number[]): TimingSummary => ({
+  p50: percentile(samples, 0.5),
+  p95: percentile(samples, 0.95),
+  max: samples.length === 0 ? 0 : Math.max(...samples),
+});
+
+export type FrameTimingRecorder = {
+  stats: () => FrameTimingStats;
+  reset: () => void;
+  stop: () => void;
+};
+
+export const startFrameTimingRecorder = (
+  events: RepaintEvents,
+  { targetFps = 60 }: { targetFps?: number } = {},
+): FrameTimingRecorder => {
+  const intervals: number[] = [];
+  const draws: number[] = [];
+
+  let frames = 0;
+  let dropped = 0;
+  let repaintStartedAt = 0;
+  let previousRepaintStartedAt: number | undefined;
+
+  const targetInterval = 1000 / targetFps;
+
+  /*
+    the ring is a plain array with a shift at capacity rather than a real ring
+    buffer. a few hundred entries at 60hz is nothing, and keeping the array in
+    chronological order means the percentile helper can just sort a copy
+  */
+  const record = (samples: number[], value: number) => {
+    samples.push(value);
+    if (samples.length > SAMPLE_CAPACITY) samples.shift();
+  };
+
+  const onBeforeRepaint = () => {
+    repaintStartedAt = performance.now();
+
+    if (previousRepaintStartedAt !== undefined) {
+      const interval = repaintStartedAt - previousRepaintStartedAt;
+      record(intervals, interval);
+      if (interval > targetInterval * DROPPED_FRAME_THRESHOLD) dropped++;
+    }
+
+    previousRepaintStartedAt = repaintStartedAt;
+    performance.mark(MARK_START);
+  };
+
+  const onAfterRepaint = () => {
+    record(draws, performance.now() - repaintStartedAt);
+    frames++;
+
+    /*
+      the measure is what puts a labelled band on the timeline in safari's
+      timelines tab and the firefox profiler, so the same instrumentation
+      serves hand profiling and the numbers below. clearing straight after
+      keeps the entry buffer from growing without bound over a long session:
+      profilers capture the entry when it is created, so nothing is lost
+    */
+    performance.measure(MEASURE_REPAINT, MARK_START);
+    performance.clearMarks(MARK_START);
+    performance.clearMeasures(MEASURE_REPAINT);
+  };
+
+  events.subscribe('onBeforeRepaint', onBeforeRepaint);
+  events.subscribe('onAfterRepaint', onAfterRepaint);
+
+  const stats = (): FrameTimingStats => {
+    const interval = summarize(intervals);
+    return {
+      frames,
+      interval,
+      draw: summarize(draws),
+      dropped,
+      fps: interval.p50 === 0 ? 0 : 1000 / interval.p50,
+    };
+  };
+
+  return {
+    stats,
+    reset: () => {
+      intervals.length = 0;
+      draws.length = 0;
+      frames = 0;
+      dropped = 0;
+      previousRepaintStartedAt = undefined;
+    },
+    stop: () => {
+      events.unsubscribe('onBeforeRepaint', onBeforeRepaint);
+      events.unsubscribe('onAfterRepaint', onAfterRepaint);
+    },
+  };
+};

--- a/packages/graph-dev-tools/src/perf/frame-timing.ts
+++ b/packages/graph-dev-tools/src/perf/frame-timing.ts
@@ -1,7 +1,5 @@
 /**
- * Frame timing for the canvas render loop.
- *
- * Two numbers, kept apart on purpose, because they answer different questions:
+ * Frame timing for the canvas render loop:
  *
  * - interval: the gap between consecutive repaints. answers "are we hitting 60"
  * - draw: how long the repaint itself takes. answers "why not"
@@ -12,7 +10,6 @@
  */
 import { percentile } from './percentile.ts';
 
-/** anything with the canvas surface's repaint events. duck typed on purpose */
 export type RepaintEvents = {
   subscribe: (event: RepaintEvent, callback: () => void) => void;
   unsubscribe: (event: RepaintEvent, callback: () => void) => void;

--- a/packages/graph-dev-tools/src/perf/index.ts
+++ b/packages/graph-dev-tools/src/perf/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Opt in performance tooling for the canvas render loop.
+ *
+ * Strictly opt in, like the getters audit next door: start and stop it yourself,
+ * nothing wires it in for you. Meant to be driven from the console during a
+ * profiling session, or from a driver script if the numbers ever get automated.
+ *
+ * @example
+ * // in a product's setup, behind import.meta.env.DEV
+ * startPerfTools(graph, graph.canvas.magicCanvas.lifecycleEvents);
+ *
+ * // then, in the console
+ * __graphPerf.scene({ nodes: 25 })
+ * __graphPerf.report()
+ */
+import {
+  type CtxCounter,
+  type CtxCounterSnapshot,
+  startCtxCounter,
+} from './ctx-counter.ts';
+import {
+  type FrameTimingStats,
+  type RepaintEvents,
+  startFrameTimingRecorder,
+} from './frame-timing.ts';
+import { type SceneGraph, type SceneOptions, buildScene } from './scene.ts';
+
+export const PERF_TOOLS_GLOBAL = '__graphPerf';
+
+export type PerfReport = {
+  timing: FrameTimingStats;
+  calls?: CtxCounterSnapshot;
+};
+
+export type PerfTools = {
+  /** build a deterministic graph of a given size to measure against */
+  scene: (options: SceneOptions) => void;
+  /**
+   * start tallying canvas calls. left off by default: the patching it does adds
+   * overhead to every draw, so timings taken with it running are not comparable
+   * to timings taken without it. measure one at a time
+   */
+  countCalls: () => void;
+  /** current numbers, also logged to the console for a profiling session */
+  report: () => PerfReport;
+  /** drop every sample collected so far. call after changing the scene */
+  reset: () => void;
+  stop: () => void;
+};
+
+export const startPerfTools = (
+  graph: SceneGraph,
+  repaintEvents: RepaintEvents,
+): PerfTools => {
+  const timing = startFrameTimingRecorder(repaintEvents);
+  let counter: CtxCounter | undefined;
+
+  const report = (): PerfReport => {
+    const result: PerfReport = {
+      timing: timing.stats(),
+      calls: counter?.snapshot(),
+    };
+
+    console.table({
+      'fps (from median interval)': result.timing.fps.toFixed(1),
+      'interval p50 (ms)': result.timing.interval.p50.toFixed(2),
+      'interval p95 (ms)': result.timing.interval.p95.toFixed(2),
+      'draw p50 (ms)': result.timing.draw.p50.toFixed(2),
+      'draw p95 (ms)': result.timing.draw.p95.toFixed(2),
+      'draw max (ms)': result.timing.draw.max.toFixed(2),
+      'dropped frames': result.timing.dropped,
+      frames: result.timing.frames,
+    });
+
+    if (result.calls) console.table(result.calls.perFrame);
+
+    return result;
+  };
+
+  const tools: PerfTools = {
+    scene: (options) => {
+      buildScene(graph, options);
+      timing.reset();
+      counter?.reset();
+    },
+    countCalls: () => {
+      if (counter) return;
+      counter = startCtxCounter(repaintEvents);
+    },
+    report,
+    reset: () => {
+      timing.reset();
+      counter?.reset();
+    },
+    stop: () => {
+      timing.stop();
+      counter?.stop();
+      delete (globalThis as Record<string, unknown>)[PERF_TOOLS_GLOBAL];
+    },
+  };
+
+  // reachable from a console or a driver script without threading a ref anywhere
+  (globalThis as Record<string, unknown>)[PERF_TOOLS_GLOBAL] = tools;
+
+  return tools;
+};

--- a/packages/graph-dev-tools/src/perf/percentile.ts
+++ b/packages/graph-dev-tools/src/perf/percentile.ts
@@ -1,0 +1,16 @@
+/**
+ * Nearest rank percentile over an unsorted sample set.
+ *
+ * Nearest rank rather than interpolated: every value returned is a frame that
+ * actually happened, which is the right property when the number is going to be
+ * read as "a frame took this long".
+ */
+export const percentile = (samples: number[], fraction: number) => {
+  if (samples.length === 0) return 0;
+
+  const sorted = samples.toSorted((a, b) => a - b);
+  const rank = Math.ceil(fraction * sorted.length);
+  const index = Math.min(Math.max(rank - 1, 0), sorted.length - 1);
+
+  return sorted[index];
+};

--- a/packages/graph-dev-tools/src/perf/scene.ts
+++ b/packages/graph-dev-tools/src/perf/scene.ts
@@ -1,0 +1,100 @@
+/**
+ * Deterministic scene generation for performance runs.
+ *
+ * Without this, two measurements are never comparable: a graph laid out by hand
+ * differs between browsers, between commits and between attempts, and the
+ * difference shows up as noise on top of whatever is being measured.
+ *
+ * Sweeping N and plotting draw duration against it is the point. A constant
+ * factor and a quadratic look identical at a single size, and the whole
+ * question here is which of the two is being paid.
+ */
+
+type SceneNode = { id: string; position: { x: number; y: number } };
+type SceneEdge = { source: string; target: string };
+
+/**
+ * the slice of the graph's action surface a scene needs. duck typed on purpose,
+ * and loosely: `addElements` picks up a `shared` argument from whichever plugins
+ * are installed, and this tool has no business knowing about any of them
+ */
+export type SceneGraph = {
+  actions: {
+    addElements: (
+      elements: { nodes: any[]; edges: any[] },
+      shared?: any,
+    ) => unknown;
+  };
+};
+
+export type SceneOptions = {
+  nodes: number;
+  /** defaults to 1.5 edges per node, near what a hand drawn graph tends to be */
+  edges?: number;
+  /** world space the nodes are scattered across */
+  width?: number;
+  height?: number;
+  seed?: number;
+};
+
+/*
+  mulberry32. a real PRNG rather than Math.random because a scene that differs
+  run to run defeats the purpose, and rather than a fixed layout because a grid
+  makes every edge the same length and hides whatever depends on edge geometry
+*/
+const createRandom = (seed: number) => {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+export const buildScene = (
+  graph: SceneGraph,
+  {
+    nodes: nodeCount,
+    edges: edgeCount = Math.round(nodeCount * 1.5),
+    width = 1200,
+    height = 700,
+    seed = 1,
+  }: SceneOptions,
+) => {
+  const random = createRandom(seed);
+
+  const nodes: SceneNode[] = Array.from({ length: nodeCount }, (_, index) => ({
+    id: `perf-node-${index}`,
+    position: {
+      x: Math.round(random() * width),
+      y: Math.round(random() * height),
+    },
+  }));
+
+  const edges: SceneEdge[] = [];
+
+  /*
+    every node past the first gets one edge to an earlier node, so the graph is
+    connected and no node renders as an isolated dot. the remainder is scattered
+    at random, which is what produces the crossings and shared endpoints that
+    the edge geometry code actually pays for
+  */
+  for (let index = 1; index < nodeCount && edges.length < edgeCount; index++) {
+    edges.push({
+      source: nodes[Math.floor(random() * index)].id,
+      target: nodes[index].id,
+    });
+  }
+
+  while (edges.length < edgeCount && nodeCount > 1) {
+    const source = nodes[Math.floor(random() * nodeCount)];
+    const target = nodes[Math.floor(random() * nodeCount)];
+    if (source.id === target.id) continue;
+    edges.push({ source: source.id, target: target.id });
+  }
+
+  graph.actions.addElements({ nodes, edges }, {});
+
+  return { nodes, edges };
+};

--- a/packages/graph-primitives/src/transactions/types.ts
+++ b/packages/graph-primitives/src/transactions/types.ts
@@ -1,5 +1,3 @@
-import { DeepReadonly } from 'ts-essentials';
-
 import { CoreEdge, CoreNode } from '../types.ts';
 
 export type TransactionPayload = {

--- a/packages/magic-shared/src/graph/useGraphDevTools.ts
+++ b/packages/magic-shared/src/graph/useGraphDevTools.ts
@@ -2,17 +2,43 @@ import {
   GettersAuditGraph,
   startGettersDiscrepancyAudit,
 } from '@graph/dev-tools/debugging/getters-audit';
+import { RepaintEvents } from '@graph/dev-tools/perf/frame-timing';
+import { startPerfTools } from '@graph/dev-tools/perf/index';
+import { SceneGraph } from '@graph/dev-tools/perf/scene';
 
 import { onBeforeUnmount, onMounted } from 'vue';
 
-export const useGraphDevTools = (graph: GettersAuditGraph) => {
+type DevToolsGraph = GettersAuditGraph &
+  SceneGraph & {
+    canvas: {
+      magicCanvas: {
+        lifecycleEvents: RepaintEvents;
+      };
+    };
+  };
+
+export const useGraphDevTools = (graph: DevToolsGraph) => {
   // @ts-expect-error add vite env to .d.ts
   if (!import.meta.env.DEV) return;
-  let cleanup: () => void;
+  const cleanups: (() => void)[] = [];
   onMounted(() => {
-    cleanup = startGettersDiscrepancyAudit(graph);
+    cleanups.push(startGettersDiscrepancyAudit(graph));
+
+    /*
+      frame timing runs from mount rather than waiting to be asked, since the
+      cost is two event subscriptions and some arithmetic, and tooling you have
+      to edit code to switch on is tooling that does not get used. the
+      expensive half (the canvas call counter) stays off until __graphPerf
+      .countCalls() asks for it
+    */
+    const perf = startPerfTools(
+      graph,
+      graph.canvas.magicCanvas.lifecycleEvents,
+    );
+    cleanups.push(perf.stop);
   });
   onBeforeUnmount(() => {
-    cleanup?.();
+    for (const cleanup of cleanups) cleanup();
+    cleanups.length = 0;
   });
 };


### PR DESCRIPTION
Nothing here changes what the app does. It measures it, so the changes that follow can be shown to have worked rather than assumed to have.

Three pieces, all opt in and all in graph-dev-tools alongside the getters audit, which sets the precedent: duck typed against the public surface, started and stopped by the caller.

- frame timing: keeps the interval between repaints separate from the time spent inside one, since a run can miss its target with a fast draw or hit it with a slow one, and a single averaged fps hides both. Marks are emitted through the User Timing API, so they annotate the timeline in Safari Timelines and the Firefox Profiler for free
- canvas call counter: tallies context calls and canvas element creation per frame. For a canvas app this is the highest signal instrument there is, turning "feels slow" into a number that can be falsified. Off by default, since patching the prototype distorts the timings
- scene generator: seeded graphs of a given size, so two measurements are comparable and sweeping N shows whether a cost is constant or quadratic

The canvas surface gains onBeforeRepaint and onAfterRepaint to hang the timing off. The canvas plugin's existing onBeforeDraw and onDraw bracket the content draw alone, which leaves out the clear and the background pattern, so timing built on those would measure the wrong thing.

Reachable from the console as __graphPerf in dev.