### PR TITLE
stop allocating an offscreen canvas per priority group

### DIFF
--- a/packages/canvas-primitives/src/drawGroup.ts
+++ b/packages/canvas-primitives/src/drawGroup.ts
@@ -1,35 +1,5 @@
+import { withScratchCanvas } from './offscreen.ts';
 import type { Shape } from './types/index.ts';
-
-/**
- * Creates an offscreen canvas that mirrors the main canvas's pixel dimensions
- * and has the same camera transform applied, ready for isolated drawing.
- */
-const createOffscreenCanvas = (
-  ctx: CanvasRenderingContext2D,
-): CanvasRenderingContext2D => {
-  const offscreen = document.createElement('canvas');
-  offscreen.width = ctx.canvas.width;
-  offscreen.height = ctx.canvas.height;
-
-  const offCtx = offscreen.getContext('2d')!;
-  offCtx.setTransform(ctx.getTransform());
-
-  return offCtx;
-};
-
-/**
- * Composites the offscreen canvas onto the main canvas.
- * Transform is reset so offscreen pixels map 1:1 to main canvas pixels.
- */
-const compositeToMain = (
-  ctx: CanvasRenderingContext2D,
-  offCtx: CanvasRenderingContext2D,
-) => {
-  ctx.save();
-  ctx.resetTransform();
-  ctx.drawImage(offCtx.canvas, 0, 0);
-  ctx.restore();
-};
 
 /**
  * Draws a group of shapes with their text areas cleanly layered on top,
@@ -61,24 +31,38 @@ const compositeToMain = (
 export const drawGroup = (ctx: CanvasRenderingContext2D, shapes: Shape[]) => {
   if (shapes.length === 0) return;
 
-  const offCtx = createOffscreenCanvas(ctx);
+  /*
+    every property read here crosses the animated shape proxy, which does real
+    work on the way through, so each shape is asked for its hole exactly once
+    and the answer carries through the passes below
+  */
+  const group = shapes.map((shape) => ({
+    shape,
+    drawHole: shape.drawTextAreaHole,
+  }));
 
-  for (const shape of shapes) {
-    shape.drawShape(offCtx);
+  const punchesHoles = group.some(({ drawHole }) => drawHole);
+
+  /*
+    the isolated surface only earns its cost when there is a hole to punch:
+    without one, the group is drawn and then blitted over unchanged, which
+    lands exactly the same pixels as drawing onto the main canvas directly.
+    node groups never punch (their text areas take the matte path), and every
+    node is its own priority group, so this is the common case by a wide margin
+  */
+  if (!punchesHoles) {
+    for (const { shape } of group) shape.drawShape(ctx);
+  } else {
+    withScratchCanvas(ctx, (scratchCtx) => {
+      for (const { shape } of group) shape.drawShape(scratchCtx);
+
+      scratchCtx.globalCompositeOperation = 'destination-out';
+      for (const { drawHole } of group) drawHole?.(scratchCtx);
+    });
   }
 
-  offCtx.globalCompositeOperation = 'destination-out';
-  for (const shape of shapes) {
-    shape.drawTextAreaHole?.(offCtx);
-  }
-
-  compositeToMain(ctx, offCtx);
-
-  for (const shape of shapes) {
-    if (shape.drawTextAreaHole) {
-      shape.drawText?.(ctx);
-    } else {
-      shape.drawTextArea?.(ctx);
-    }
+  for (const { shape, drawHole } of group) {
+    if (drawHole) shape.drawText?.(ctx);
+    else shape.drawTextArea?.(ctx);
   }
 };

--- a/packages/canvas-primitives/src/offscreen.ts
+++ b/packages/canvas-primitives/src/offscreen.ts
@@ -1,0 +1,74 @@
+/**
+ * A scratch canvas for compositing, shared across the whole app.
+ *
+ * Allocating one per use was the single most expensive thing a frame did.
+ * `drawGroup` runs once per priority group and every node is its own group, so
+ * an N node graph was creating N+1 canvases the size of the entire viewport,
+ * sixty times a second. At 1440p on a retina display that is a ~59MB backing
+ * store each. Chrome recycles those aggressively enough to hide it; gecko and
+ * webkit do not, which is the whole reason this file exists.
+ *
+ * Reuse means one at a time, and drawing is not always one at a time: a shape
+ * can build nested shapes inside its own draw, and a nested one with a
+ * no-matte text area wants a scratch surface while the outer one is still
+ * using its own. So the pool is indexed by depth rather than being a single
+ * canvas, and a nested acquire gets its own.
+ */
+
+const createScratchCtx = () => {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2d context not found on scratch canvas');
+  return ctx;
+};
+
+const scratchByDepth: CanvasRenderingContext2D[] = [];
+let depth = 0;
+
+const prepare = (
+  scratch: CanvasRenderingContext2D,
+  ctx: CanvasRenderingContext2D,
+) => {
+  const { width, height } = ctx.canvas;
+
+  if (scratch.canvas.width !== width || scratch.canvas.height !== height) {
+    // assigning either dimension resets the bitmap and every context property
+    scratch.canvas.width = width;
+    scratch.canvas.height = height;
+  } else {
+    scratch.resetTransform();
+    scratch.clearRect(0, 0, width, height);
+  }
+
+  // the previous user may have left this mid punch
+  scratch.globalCompositeOperation = 'source-over';
+  scratch.setTransform(ctx.getTransform());
+};
+
+/**
+ * Draws into an isolated surface matching the main canvas's pixel dimensions and
+ * camera transform, then composites the result onto the main canvas.
+ *
+ * The isolation is what lets a caller erase pixels with `destination-out`
+ * without taking out whatever was already on the main canvas underneath.
+ */
+export const withScratchCanvas = (
+  ctx: CanvasRenderingContext2D,
+  drawIntoScratch: (scratchCtx: CanvasRenderingContext2D) => void,
+) => {
+  const scratch = (scratchByDepth[depth] ??= createScratchCtx());
+  depth++;
+
+  try {
+    prepare(scratch, ctx);
+    drawIntoScratch(scratch);
+
+    // transform is reset so scratch pixels map 1:1 onto the main canvas
+    ctx.save();
+    ctx.resetTransform();
+    ctx.drawImage(scratch.canvas, 0, 0);
+    ctx.restore();
+  } finally {
+    depth--;
+  }
+};

--- a/packages/canvas-primitives/src/text/drawWithNoMatte.ts
+++ b/packages/canvas-primitives/src/text/drawWithNoMatte.ts
@@ -1,27 +1,11 @@
 import type { DeepRequired } from 'ts-essentials';
 
+import { withScratchCanvas } from '../offscreen.ts';
 import type { getTextAreaDimension } from './text.ts';
 import type { TextAreaWithAnchorPoint } from './types.ts';
 
 type DrawFn = (ctx: CanvasRenderingContext2D) => void;
 type TextAreaDimensions = ReturnType<typeof getTextAreaDimension>;
-
-/**
- * Creates an offscreen canvas that mirrors the main canvas's pixel dimensions
- * and has the same camera transform applied, ready for isolated drawing.
- */
-const createOffscreenCanvas = (
-  ctx: CanvasRenderingContext2D,
-): CanvasRenderingContext2D => {
-  const offscreen = document.createElement('canvas');
-  offscreen.width = ctx.canvas.width;
-  offscreen.height = ctx.canvas.height;
-
-  const offCtx = offscreen.getContext('2d')!;
-  offCtx.setTransform(ctx.getTransform());
-
-  return offCtx;
-};
 
 /**
  * Punches a transparent rectangle into the offscreen canvas at the text area's position.
@@ -43,20 +27,6 @@ const punchTextAreaHole = (
 };
 
 /**
- * Composites the offscreen canvas onto the main canvas.
- * Transform is reset so offscreen pixels map 1:1 to main canvas pixels.
- */
-const compositeToMain = (
-  ctx: CanvasRenderingContext2D,
-  offCtx: CanvasRenderingContext2D,
-) => {
-  ctx.save();
-  ctx.resetTransform();
-  ctx.drawImage(offCtx.canvas, 0, 0);
-  ctx.restore();
-};
-
-/**
  * Draws a shape with a no-matte text area using offscreen canvas compositing.
  *
  * Instead of painting a solid matte behind the text, the shape is rendered to an
@@ -75,11 +45,10 @@ export const drawWithNoMatte = (
   dimensions: TextAreaDimensions,
   drawText: DrawFn,
 ) => {
-  const offCtx = createOffscreenCanvas(ctx);
-
-  drawShape(offCtx);
-  punchTextAreaHole(offCtx, textArea, dimensions);
-  compositeToMain(ctx, offCtx);
+  withScratchCanvas(ctx, (scratchCtx) => {
+    drawShape(scratchCtx);
+    punchTextAreaHole(scratchCtx, textArea, dimensions);
+  });
 
   drawText(ctx);
 };


### PR DESCRIPTION
drawGroup created a fresh full viewport canvas every time it ran, and it runs once per priority group. Every node is its own group, so an N node graph allocated N+1 canvases the size of the whole viewport, sixty times a second. At 1440p on a retina display that is a ~59MB backing store each. Chrome recycles those aggressively enough to hide it. Gecko and WebKit do not, which is most of why the app is unusable there and fine in Chrome.

Two changes:

- one scratch surface, reused, resized only when the main canvas changes size. It is pooled by nesting depth rather than being a single canvas, since a shape can build nested shapes inside its own draw and a nested one with a no-matte text area needs its own surface while the outer is still using its.
- the offscreen is skipped entirely when no shape in the group punches a hole. It only exists so destination-out can erase pixels without taking out what sits underneath; with no hole to punch, the group is drawn and then blitted over unchanged, which is the same pixels as drawing straight to the main canvas. Node groups never punch, and every node is its own group, so this is the common case by a wide margin.

drawWithNoMatte carried its own copy of the same two helpers and now shares them.