### PR TITLE
perf: cache text measurement instead of remaking a canvas per call

### DIFF
--- a/packages/canvas-primitives/src/text/getTextDimensions.ts
+++ b/packages/canvas-primitives/src/text/getTextDimensions.ts
@@ -1,30 +1,70 @@
-import { getCtx } from '@core/utils/ctx/index';
-
 import type { TextBlock } from './types.ts';
 
-export const getTextDimensions = (text: Required<TextBlock>) => {
-  const { content, fontSize, fontWeight, fontFamily } = text;
+type TextDimensions = {
+  width: number;
+  height: number;
+  ascent: number;
+  descent: number;
+};
+
+/*
+  measuring used to create a canvas element and a 2d context per call, and the
+  call happens inside every shape factory, and every shape is rebuilt from
+  scratch on every draw. that put the cost at one element and one context per
+  labeled shape per frame, plus another full set on every mousemove, all to
+  re-derive numbers that had not changed since the last time they were asked
+  for.
+
+  one canvas, made once. the dimensions stay at the 1x1 default: measureText
+  reads nothing off the bitmap
+*/
+let measureCtx: CanvasRenderingContext2D | undefined;
+
+const getMeasureCtx = () => {
+  if (measureCtx) return measureCtx;
 
   const canvas = document.createElement('canvas');
-  const ctx = getCtx(canvas);
-
-  canvas.width = 1;
-  canvas.height = 1;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2d context not found on text measuring canvas');
 
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
-  ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+  measureCtx = ctx;
+  return measureCtx;
+};
+
+/*
+  unbounded on purpose. the key space is the distinct labels actually on screen,
+  which at the graph sizes this is built for is a few dozen strings, so eviction
+  would cost more code than the memory it saves
+*/
+const cache = new Map<string, TextDimensions>();
+
+export const getTextDimensions = (text: Required<TextBlock>) => {
+  const { content, fontSize, fontWeight, fontFamily } = text;
+
+  const font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+  const key = `${font}|${content}`;
+
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const ctx = getMeasureCtx();
+  ctx.font = font;
   const metrics = ctx.measureText(content);
 
   const ascent = metrics.actualBoundingBoxAscent;
   const descent = metrics.actualBoundingBoxDescent;
-  const height = ascent + descent;
 
-  return {
+  const dimensions: TextDimensions = {
     width: metrics.width,
-    height,
+    height: ascent + descent,
     ascent,
     descent,
   };
+
+  cache.set(key, dimensions);
+
+  return dimensions;
 };


### PR DESCRIPTION
getTextDimensions created a canvas element and a 2d context on every call, and it is called inside every shape factory, and every shape is rebuilt from scratch on every draw. That put it at one element plus one context plus one measureText per labeled shape per frame, and another full set on every mousemove, all to re-derive numbers that had not changed since the last time they were asked for.

One measuring canvas, made once, plus a memo keyed on font and content.

The map is unbounded on purpose: the key space is the distinct labels on screen, which at the sizes this is built for is a few dozen strings, so eviction would cost more code than the memory it saves. Safe against late loading fonts only because every text block resolves to Arial; a web font would need the cache dropped on document.fonts.ready.