### PR TITLE
perf: drive the render loop with requestAnimationFrame

### DIFF
--- a/packages/canvas-surface/src/index.ts
+++ b/packages/canvas-surface/src/index.ts
@@ -13,6 +13,15 @@ import type { DrawContent, UseCanvas } from './types.ts';
 
 const REPAINT_FPS = 60;
 
+/*
+  the slack matters. a 60hz display does not hand out frames exactly 16.667ms
+  apart, so comparing against the period on the nose rejects the frame that
+  arrives at 16.6 and waits for the next one, halving the rate to 30. a
+  millisecond of give takes every frame on a 60hz screen and still rejects the
+  8.3ms half frames a 120hz screen offers
+*/
+const MS_PER_REPAINT = 1000 / REPAINT_FPS - 1;
+
 const initCanvasWidthHeight = (canvas: HTMLCanvasElement | undefined) => {
   if (!canvas) throw new Error('Canvas not found in DOM. Check ref link.');
 
@@ -31,11 +40,39 @@ export const useCanvas: UseCanvas = () => {
 
   const lifecycleEvents = createEventHub(createCanvasLifecycleEventRegistry());
 
-  let repaintInterval: NodeJS.Timeout;
+  let repaintFrame: number | undefined;
+  /*
+    resolved once per canvas element rather than per frame. getContext hands
+    back the same context every time, but the lookup itself was showing up 60
+    times a second for no reason
+  */
+  let ctx: CanvasRenderingContext2D | undefined;
+
+  /*
+    the loop follows the browser's frame instead of a timer that drifts against
+    it. a setInterval that overruns its own period queues the next repaint
+    immediately and never gets to skip one, which is how a slow frame turned
+    into a permanently behind one on gecko and webkit
+
+    the cap keeps the workload where it was: rAF runs at the display's refresh
+    rate, so a 120hz screen would otherwise silently double the number of
+    frames drawn per second
+  */
+  let lastRepaintAt = 0;
+
+  const scheduleRepaint = () => {
+    repaintFrame = requestAnimationFrame((now) => {
+      scheduleRepaint();
+      if (now - lastRepaintAt < MS_PER_REPAINT) return;
+      lastRepaintAt = now;
+      repaintCanvas();
+    });
+  };
 
   onMounted(() => {
     initCanvasWidthHeight(canvas.value);
-    repaintInterval = setInterval(repaintCanvas, 1000 / REPAINT_FPS);
+    ctx = getCtx(canvas);
+    scheduleRepaint();
     lifecycleEvents.emit('onMounted');
   });
 
@@ -43,9 +80,10 @@ export const useCanvas: UseCanvas = () => {
     lifecycleEvents.emit('onBeforeUnmount');
   });
 
-  watch([canvasBoxSize.width, canvasBoxSize.height], () =>
-    initCanvasWidthHeight(canvas.value),
-  );
+  watch([canvasBoxSize.width, canvasBoxSize.height], () => {
+    initCanvasWidthHeight(canvas.value);
+    ctx = getCtx(canvas);
+  });
 
   const { cleanup: cleanupCamera, ...camera } = useCamera(canvas);
   const { coordinates: cursorCoordinates, cleanup: cleanupCoords } =
@@ -54,7 +92,7 @@ export const useCanvas: UseCanvas = () => {
   const pattern = useBackgroundPattern(camera.state, drawBackgroundPattern);
 
   const repaintCanvas = () => {
-    const ctx = getCtx(canvas);
+    if (!ctx) return;
     camera.transformAndClear(ctx);
     pattern.draw(ctx);
     drawContent.value(ctx);
@@ -69,7 +107,8 @@ export const useCanvas: UseCanvas = () => {
       cleanup: (ref) => {
         cleanupCoords(ref);
         cleanupCamera(ref);
-        clearInterval(repaintInterval);
+        if (repaintFrame !== undefined) cancelAnimationFrame(repaintFrame);
+        ctx = undefined;
       },
     },
     draw: {


### PR DESCRIPTION
The repaint ran on a setInterval at 60fps: not vsync aligned, never skipped, and still ticking on a hidden tab. An interval that overruns its own period queues the next repaint immediately and never gets the chance to drop one, so a single slow frame turns into permanently behind, which is the failure mode on Gecko and WebKit specifically.

rAF instead, capped by skipping frames that arrive early. The cap keeps the workload where it is today: rAF fires at the display's refresh rate, so a 120hz screen would otherwise silently double the frames drawn per second before any of this is fast enough to want that.

The cap compares against the period minus a millisecond of slack. A 60hz display does not hand out frames exactly 16.667ms apart, and comparing on the nose rejects the one that arrives at 16.6 and waits for the next, halving the rate to 30.

getCtx also moves out of the repaint: it called getContext fresh sixty times a second to get back the same object every time. Resolved on mount and on resize, the two points where the canvas element can change.