### PR TITLE
perf: trim the work a frame repeats for no gain

### DIFF
--- a/packages/canvas-primitives/src/animation/index.ts
+++ b/packages/canvas-primitives/src/animation/index.ts
@@ -324,16 +324,30 @@ export const createAnimatedShapes = () => {
   // equal to, not less than, every group's new end) is claimed by exactly
   // one group instead of falling through every group's exclusive range
   const ghostsPlacedThisFrame = new Set<SchemaId>();
+  /*
+    built once a frame rather than once per group. every node is its own
+    priority group, so asking per group meant rebuilding the same list N times
+    to draw N nodes, and it is empty almost always. the shapes it hands back
+    resolve their animated values when read, not when built, so one build
+    serves the whole frame without freezing anything mid animation
+  */
+  let ghostsThisFrame: ReturnType<typeof getGhostShapes> = [];
+
   const beginFrame = () => {
     shapesDrawnThisFrame = 0;
     ghostsPlacedThisFrame.clear();
+    ghostsThisFrame = getGhostShapes();
   };
 
   const drawGroup = (ctx: CanvasRenderingContext2D, groupShapes: Shape[]) => {
     const groupStart = shapesDrawnThisFrame;
     const groupEnd = groupStart + groupShapes.length;
 
-    const ghostsInGroup = getGhostShapes().filter(
+    shapesDrawnThisFrame = groupEnd;
+
+    if (ghostsThisFrame.length === 0) return drawGroupPure(ctx, groupShapes);
+
+    const ghostsInGroup = ghostsThisFrame.filter(
       ({ id, orderIndex }) =>
         !ghostsPlacedThisFrame.has(id) &&
         orderIndex >= groupStart &&
@@ -350,8 +364,6 @@ export const createAnimatedShapes = () => {
       );
     }
 
-    shapesDrawnThisFrame = groupEnd;
-
     drawGroupPure(ctx, shapesWithGhosts);
   };
 
@@ -364,7 +376,7 @@ export const createAnimatedShapes = () => {
    * calls, to draw any ghosts that were never claimed by one.
    */
   const endFrame = (ctx: CanvasRenderingContext2D) => {
-    const unclaimedGhosts = getGhostShapes().filter(
+    const unclaimedGhosts = ghostsThisFrame.filter(
       ({ id }) => !ghostsPlacedThisFrame.has(id),
     );
     if (unclaimedGhosts.length === 0) return;

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -141,10 +141,19 @@ export const canvas =
       }).draw(ctx);
     };
 
+    // the color only moves on a theme switch, so the write is skipped rather
+    // than repeated at every frame
+    let writtenBackgroundColor: string | undefined;
+
     canvasEvents.subscribe('onDraw', () => {
       const canvas = magicCanvas.canvas.value;
       if (!canvas) return;
-      canvas.style.backgroundColor = theme._resolveToken('canvas.color');
+
+      const backgroundColor = theme._resolveToken('canvas.color');
+      if (writtenBackgroundColor === backgroundColor) return;
+
+      canvas.style.backgroundColor = backgroundColor;
+      writtenBackgroundColor = backgroundColor;
     });
 
     let getNodePriority = createNodeCanvasElementPriorityGetter({

--- a/packages/graph-plugins/src/canvas/setupCanvasCursor.ts
+++ b/packages/graph-plugins/src/canvas/setupCanvasCursor.ts
@@ -48,11 +48,15 @@ export const setupCanvasCursor = ({
     return elementCursor;
   };
 
+  // remembered rather than read back off the element, since this runs per frame
+  let writtenCursor: Cursor | undefined;
+
   const refreshCursor = () => {
     if (!canvas.value) return;
-    const currentCursor = canvas.value.style.cursor;
     const newCursor = getCursor();
-    if (currentCursor !== newCursor) canvas.value.style.cursor = newCursor;
+    if (writtenCursor === newCursor) return;
+    canvas.value.style.cursor = newCursor;
+    writtenCursor = newCursor;
   };
 
   subscribe('onDraw', refreshCursor);


### PR DESCRIPTION
Three small ones, none of them structural:

- getGhostShapes ran inside every drawGroup call, so with every node in its own priority group it rebuilt the same list N times to draw N nodes, and the list is empty almost always. Built once per frame in beginFrame instead. The shapes it returns resolve their animated values when read rather than when built, so one build serves the whole frame without freezing anything mid animation. A group with no ghosts also skips copying its shape array now.
- the canvas background color was resolved and written to style every frame. It only moves on a theme switch.
- the cursor read its own value back off the element each frame to compare against. Remembered instead.