### PR TITLE
build the background pattern cell once a frame, not once a cell

### DIFF
--- a/packages/canvas-primitives/src/shapes/cross/draw.ts
+++ b/packages/canvas-primitives/src/shapes/cross/draw.ts
@@ -16,38 +16,46 @@ export const drawCrossWithCtx = (schema: CrossSchemaWithDefaults) => {
   const [topLeft, topRight, bottomLeft, bottomRight] =
     toBorderRadiusArray(borderRadius);
 
+  /*
+    the three bars are built here rather than inside the draw below because
+    nothing about them varies per call: they sit at fixed offsets from the
+    cross's own origin and the transform is what moves them. the background
+    pattern stamps a cross a few thousand times a frame, so a rect built per
+    draw is a rect built per stamp
+  */
+  const drawVerticalTop = rect({
+    at: { x: -halfLineWidth, y: -size / 2 },
+    width: lineWidth,
+    height: size / 2 - halfLineWidth,
+    fillColor,
+    borderRadius: [topLeft, topLeft, 0, 0],
+  }).drawShape;
+
+  const drawHorizontal = rect({
+    at: { x: -size / 2, y: -halfLineWidth },
+    width: size,
+    height: lineWidth,
+    fillColor,
+    borderRadius: [bottomRight, topRight, topRight, bottomRight],
+  }).drawShape;
+
+  const drawVerticalBottom = rect({
+    at: { x: -halfLineWidth, y: halfLineWidth },
+    width: lineWidth,
+    height: size / 2 - halfLineWidth,
+    fillColor,
+    borderRadius: [0, 0, bottomLeft, bottomLeft],
+  }).drawShape;
+
   return (ctx: CanvasRenderingContext2D) => {
     ctx.save();
 
     ctx.translate(crossAt.x, crossAt.y);
     ctx.rotate(rotation);
 
-    // vertical top
-    rect({
-      at: { x: -halfLineWidth, y: -size / 2 },
-      width: lineWidth,
-      height: size / 2 - halfLineWidth,
-      fillColor,
-      borderRadius: [topLeft, topLeft, 0, 0],
-    }).drawShape(ctx);
-
-    // horizontal
-    rect({
-      at: { x: -size / 2, y: -halfLineWidth },
-      width: size,
-      height: lineWidth,
-      fillColor,
-      borderRadius: [bottomRight, topRight, topRight, bottomRight],
-    }).drawShape(ctx);
-
-    // vertical bottom
-    rect({
-      at: { x: -halfLineWidth, y: halfLineWidth },
-      width: lineWidth,
-      height: size / 2 - halfLineWidth,
-      fillColor,
-      borderRadius: [0, 0, bottomLeft, bottomLeft],
-    }).drawShape(ctx);
+    drawVerticalTop(ctx);
+    drawHorizontal(ctx);
+    drawVerticalBottom(ctx);
 
     ctx.restore();
   };

--- a/packages/canvas-surface/src/backgroundPattern.ts
+++ b/packages/canvas-surface/src/backgroundPattern.ts
@@ -23,11 +23,10 @@ const computeAlpha = (z: number) => {
 /**
  * Prepares the pattern for a frame and returns how to stamp a single cell of it.
  *
- * Split in two because the cell count is large and everything except the
- * position is the same for all of them. Handed a per cell draw instead, the
- * implementation had nowhere to put the work that does not vary, and ended up
- * rebuilding its shapes and re-resolving its color a few thousand times a
- * frame.
+ * Two stages because position is the only thing that differs between cells, and
+ * at low zoom there are a few thousand of them. The outer call is where an
+ * implementation builds its shapes and resolves its color, once, and the
+ * returned function is the only thing the frame runs per cell.
  */
 export type DrawPattern = (
   ctx: CanvasRenderingContext2D,

--- a/packages/canvas-surface/src/backgroundPattern.ts
+++ b/packages/canvas-surface/src/backgroundPattern.ts
@@ -20,17 +20,32 @@ const computeAlpha = (z: number) => {
   return strPercent.length === 1 ? `0${strPercent}` : strPercent;
 };
 
+/**
+ * Prepares the pattern for a frame and returns how to stamp a single cell of it.
+ *
+ * Split in two because the cell count is large and everything except the
+ * position is the same for all of them. Handed a per cell draw instead, the
+ * implementation had nowhere to put the work that does not vary, and ended up
+ * rebuilding its shapes and re-resolving its color a few thousand times a
+ * frame.
+ */
 export type DrawPattern = (
   ctx: CanvasRenderingContext2D,
-  at: Coordinate,
   alpha: string,
-) => void;
+) => (at: Coordinate) => void;
 
 export const useBackgroundPattern = (
   { panX, panY, zoom }: Camera['state'],
   drawPattern: DrawFns['backgroundPattern'],
 ) => {
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  /**
+   * @param canvasRect the canvas's on screen position, passed in rather than
+   * measured here: both corners below need it, and reading it forces layout
+   */
+  const draw = (
+    ctx: CanvasRenderingContext2D,
+    canvasRect: Pick<DOMRect, 'left' | 'top'>,
+  ) => {
     if (zoom.value <= PATTERN_FULLY_FADED_OUT) return;
 
     const startingCoords = getCoordinates(
@@ -39,6 +54,7 @@ export const useBackgroundPattern = (
         clientY: 0,
       },
       ctx,
+      canvasRect,
     );
 
     const endingCoords = getCoordinates(
@@ -47,10 +63,14 @@ export const useBackgroundPattern = (
         clientY: window.innerHeight + STAGGER,
       },
       ctx,
+      canvasRect,
     );
 
     const offsetX = (panX.value / zoom.value) % STAGGER;
     const offsetY = (panY.value / zoom.value) % STAGGER;
+
+    // the alpha follows zoom alone, so it is the same string for every cell
+    const drawCell = drawPattern.value(ctx, computeAlpha(zoom.value));
 
     for (let x = startingCoords.x + offsetX; x < endingCoords.x; x += STAGGER) {
       for (
@@ -58,7 +78,7 @@ export const useBackgroundPattern = (
         y < endingCoords.y;
         y += STAGGER
       ) {
-        drawPattern.value(ctx, { x, y }, computeAlpha(zoom.value));
+        drawCell({ x, y });
       }
     }
   };

--- a/packages/canvas-surface/src/coordinates/index.ts
+++ b/packages/canvas-surface/src/coordinates/index.ts
@@ -41,8 +41,13 @@ export type WithZoom<T> = T & {
 export const getCoordinates = (
   clientCoords: ClientCoords,
   ctx: CanvasRenderingContext2D,
+  /**
+   * the canvas's position on screen. reading it forces layout, so a caller in
+   * the draw path should hand over one it already has rather than let this
+   * measure per call
+   */
+  rect: Pick<DOMRect, 'left' | 'top'> = ctx.canvas.getBoundingClientRect(),
 ): WithZoom<Coords> => {
-  const rect = ctx.canvas.getBoundingClientRect();
   const localX = clientCoords.clientX - rect.left;
   const localY = clientCoords.clientY - rect.top;
 

--- a/packages/canvas-surface/src/coordinates/index.ts
+++ b/packages/canvas-surface/src/coordinates/index.ts
@@ -42,9 +42,9 @@ export const getCoordinates = (
   clientCoords: ClientCoords,
   ctx: CanvasRenderingContext2D,
   /**
-   * the canvas's position on screen. reading it forces layout, so a caller in
-   * the draw path should hand over one it already has rather than let this
-   * measure per call
+   * the canvas's position on screen. measuring it forces layout, so callers on
+   * the draw path should pass one they already hold and leave the default to
+   * one off callers like event handlers
    */
   rect: Pick<DOMRect, 'left' | 'top'> = ctx.canvas.getBoundingClientRect(),
 ): WithZoom<Coords> => {

--- a/packages/canvas-surface/src/index.ts
+++ b/packages/canvas-surface/src/index.ts
@@ -20,6 +20,8 @@ const initCanvasWidthHeight = (canvas: HTMLCanvasElement | undefined) => {
   const rect = canvas.getBoundingClientRect();
   canvas.width = rect.width * dpr;
   canvas.height = rect.height * dpr;
+
+  return rect;
 };
 
 export const useCanvas: UseCanvas = () => {
@@ -27,14 +29,22 @@ export const useCanvas: UseCanvas = () => {
   const canvasBoxSize = useElementSize(canvas);
 
   const drawContent = ref<DrawContent>(() => {});
-  const drawBackgroundPattern = ref<DrawPattern>(() => {});
+  const drawBackgroundPattern = ref<DrawPattern>(() => () => {});
+
+  /*
+    the background pattern needs the canvas's screen position to work out which
+    slice of the world is visible, and reading it forces layout. the canvas
+    fills the viewport, so the only thing that moves it is a resize, which is
+    already being watched
+  */
+  let canvasRect: Pick<DOMRect, 'left' | 'top'> = { left: 0, top: 0 };
 
   const lifecycleEvents = createEventHub(createCanvasLifecycleEventRegistry());
 
   let repaintInterval: NodeJS.Timeout;
 
   onMounted(() => {
-    initCanvasWidthHeight(canvas.value);
+    canvasRect = initCanvasWidthHeight(canvas.value);
     repaintInterval = setInterval(repaintCanvas, 1000 / REPAINT_FPS);
     lifecycleEvents.emit('onMounted');
   });
@@ -43,9 +53,9 @@ export const useCanvas: UseCanvas = () => {
     lifecycleEvents.emit('onBeforeUnmount');
   });
 
-  watch([canvasBoxSize.width, canvasBoxSize.height], () =>
-    initCanvasWidthHeight(canvas.value),
-  );
+  watch([canvasBoxSize.width, canvasBoxSize.height], () => {
+    canvasRect = initCanvasWidthHeight(canvas.value);
+  });
 
   const { cleanup: cleanupCamera, ...camera } = useCamera(canvas);
   const { coordinates: cursorCoordinates, cleanup: cleanupCoords } =
@@ -56,7 +66,7 @@ export const useCanvas: UseCanvas = () => {
   const repaintCanvas = () => {
     const ctx = getCtx(canvas);
     camera.transformAndClear(ctx);
-    pattern.draw(ctx);
+    pattern.draw(ctx, canvasRect);
     drawContent.value(ctx);
   };
 

--- a/packages/canvas-surface/src/index.ts
+++ b/packages/canvas-surface/src/index.ts
@@ -13,7 +13,12 @@ import type { DrawContent, UseCanvas } from './types.ts';
 
 const REPAINT_FPS = 60;
 
-const initCanvasWidthHeight = (canvas: HTMLCanvasElement | undefined) => {
+/**
+ * measures the canvas, sizes its backing store to match at the current device
+ * pixel ratio, and hands the measurement back so callers that need the canvas's
+ * screen position do not have to pay for a second layout to get it
+ */
+const measureAndSizeCanvas = (canvas: HTMLCanvasElement | undefined) => {
   if (!canvas) throw new Error('Canvas not found in DOM. Check ref link.');
 
   const dpr = getDevicePixelRatio();
@@ -44,7 +49,7 @@ export const useCanvas: UseCanvas = () => {
   let repaintInterval: NodeJS.Timeout;
 
   onMounted(() => {
-    canvasRect = initCanvasWidthHeight(canvas.value);
+    canvasRect = measureAndSizeCanvas(canvas.value);
     repaintInterval = setInterval(repaintCanvas, 1000 / REPAINT_FPS);
     lifecycleEvents.emit('onMounted');
   });
@@ -54,7 +59,7 @@ export const useCanvas: UseCanvas = () => {
   });
 
   watch([canvasBoxSize.width, canvasBoxSize.height], () => {
-    canvasRect = initCanvasWidthHeight(canvas.value);
+    canvasRect = measureAndSizeCanvas(canvas.value);
   });
 
   const { cleanup: cleanupCamera, ...camera } = useCamera(canvas);

--- a/packages/canvas-surface/src/index.ts
+++ b/packages/canvas-surface/src/index.ts
@@ -11,6 +11,8 @@ import { useCoordinates } from './coordinates/index.ts';
 import { createCanvasLifecycleEventRegistry } from './events.ts';
 import type { DrawContent, UseCanvas } from './types.ts';
 
+const REPAINT_FPS = 60;
+
 /*
   the slack matters. a 60hz display does not hand out frames exactly 16.667ms
   apart, so comparing against the period on the nose rejects the frame that
@@ -84,7 +86,6 @@ export const useCanvas: UseCanvas = () => {
 
   onMounted(() => {
     canvasRect = measureAndSizeCanvas(canvas.value);
-    initCanvasWidthHeight(canvas.value);
     ctx = getCtx(canvas);
     scheduleRepaint();
     lifecycleEvents.emit('onMounted');
@@ -96,7 +97,6 @@ export const useCanvas: UseCanvas = () => {
 
   watch([canvasBoxSize.width, canvasBoxSize.height], () => {
     canvasRect = measureAndSizeCanvas(canvas.value);
-    initCanvasWidthHeight(canvas.value);
     ctx = getCtx(canvas);
   });
 

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -132,13 +132,32 @@ export const canvas =
       }
     });
 
-    magicCanvas.draw.backgroundPattern.value = (ctx, at, alpha) => {
-      cross({
-        at,
+    /*
+      the cell is built once and then stamped, rather than built per cell. a
+      cross constructs three rects of its own on the way down, so at low zoom
+      the old shape-per-cell version was putting sixteen thousand shape objects
+      through the allocator every frame to draw the same twelve pixels over and
+      over
+
+      translating for each stamp is what makes one shape enough: the cross is
+      built at the origin and the transform carries it to where it belongs
+    */
+    magicCanvas.draw.backgroundPattern.value = (ctx, alpha) => {
+      const origin = { x: 0, y: 0 };
+
+      const cell = cross({
+        at: origin,
         size: 12,
         lineWidth: 1,
-        fillColor: theme._resolveToken('canvas.patternColor', at, alpha),
-      }).draw(ctx);
+        fillColor: theme._resolveToken('canvas.patternColor', alpha),
+      });
+
+      return (at) => {
+        ctx.save();
+        ctx.translate(at.x, at.y);
+        cell.draw(ctx);
+        ctx.restore();
+      };
     };
 
     canvasEvents.subscribe('onDraw', () => {

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -133,14 +133,14 @@ export const canvas =
     });
 
     /*
-      the cell is built once and then stamped, rather than built per cell. a
-      cross constructs three rects of its own on the way down, so at low zoom
-      the old shape-per-cell version was putting sixteen thousand shape objects
-      through the allocator every frame to draw the same twelve pixels over and
-      over
+      everything that does not depend on where a cell lands is hoisted out of
+      the stamp: the theme lookup, and the cross itself, which resolves its
+      schema, builds the three bars it draws with, and builds a hitbox, a
+      bounding box and text props the pattern never asks for. what is left per
+      cell is a translate and a draw
 
-      translating for each stamp is what makes one shape enough: the cross is
-      built at the origin and the transform carries it to where it belongs
+      the cross is built at the origin, so that translate is what puts each
+      stamp where it belongs
     */
     magicCanvas.draw.backgroundPattern.value = (ctx, alpha) => {
       const origin = { x: 0, y: 0 };

--- a/packages/graph-plugins/src/canvas/themes.ts
+++ b/packages/graph-plugins/src/canvas/themes.ts
@@ -51,7 +51,12 @@ export type EdgeThemeValues = {
 
 type CanvasThemeValues = {
   color: ThemeValue<string>;
-  patternColor: ThemeValue<string, [Coordinate, alpha: string]>;
+  /*
+    no coordinate here. the pattern is stamped a few thousand times a frame at
+    low zoom, so it is resolved once per frame and reused for every cell, which
+    a per cell coordinate would rule out. no preset ever varied on it
+  */
+  patternColor: ThemeValue<string, [alpha: string]>;
   cursor: ThemeValue<Cursor | CursorFallback>;
 };
 

--- a/packages/graph-plugins/src/canvas/themes.ts
+++ b/packages/graph-plugins/src/canvas/themes.ts
@@ -52,9 +52,10 @@ export type EdgeThemeValues = {
 type CanvasThemeValues = {
   color: ThemeValue<string>;
   /*
-    no coordinate here. the pattern is stamped a few thousand times a frame at
-    low zoom, so it is resolved once per frame and reused for every cell, which
-    a per cell coordinate would rule out. no preset ever varied on it
+    takes the alpha and nothing else. the pattern covers the viewport a few
+    thousand cells at a time at low zoom, so this resolves once a frame and the
+    result is reused for every cell. a coordinate argument would force it back
+    to once a cell to mean anything
   */
   patternColor: ThemeValue<string, [alpha: string]>;
   cursor: ThemeValue<Cursor | CursorFallback>;

--- a/packages/graph-theme-presets/src/dark/index.ts
+++ b/packages/graph-theme-presets/src/dark/index.ts
@@ -16,7 +16,7 @@ export const dark: DarkPreset = {
   canvas: {
     'canvas.color': colors.GRAY_600,
     'canvas.cursor': CURSOR_FALLBACK,
-    'canvas.patternColor': (_, alpha) => colors.GRAY_500 + alpha,
+    'canvas.patternColor': (alpha) => colors.GRAY_500 + alpha,
 
     'edge.default.color': colors.STONE_900,
     'edge.default.cursor': shared.edge.cursor,

--- a/packages/graph-theme-presets/src/light/index.ts
+++ b/packages/graph-theme-presets/src/light/index.ts
@@ -16,7 +16,7 @@ export const light: LightPreset = {
   canvas: {
     'canvas.color': colors.GRAY_300,
     'canvas.cursor': CURSOR_FALLBACK,
-    'canvas.patternColor': (_, alpha) => colors.GRAY_500 + alpha,
+    'canvas.patternColor': (alpha) => colors.GRAY_500 + alpha,
 
     'edge.default.color': colors.GRAY_800,
     'edge.default.cursor': shared.edge.cursor,

--- a/packages/graph-theme-presets/src/pink/index.ts
+++ b/packages/graph-theme-presets/src/pink/index.ts
@@ -16,7 +16,7 @@ export const pink: PinkPreset = {
   canvas: {
     'canvas.color': colors.PINK_300,
     'canvas.cursor': CURSOR_FALLBACK,
-    'canvas.patternColor': (_, alpha) => colors.PURPLE_200 + alpha,
+    'canvas.patternColor': (alpha) => colors.PURPLE_200 + alpha,
 
     'edge.default.color': colors.PINK_600,
     'edge.default.cursor': shared.edge.cursor,


### PR DESCRIPTION
The pattern loop called into the plugin once per grid cell, and the plugin built a cross for each call, and a cross builds three rects of its own inside its draw. At zoom 1 on a 1440p display that is ~400 cells and ~1,600 shape objects a frame; at zoom 0.3 the visible world grows to ~4,000 cells and ~16,000 objects, every frame, to draw the same twelve pixels over and over. computeAlpha also re-ran its string formatting per cell while depending only on zoom.

DrawPattern becomes a per frame factory returning a per cell stamp, so the implementation finally has somewhere to put the work that does not vary: one cross, one resolved color, one alpha string, then translate and draw per cell.

canvas.patternColor loses its coordinate argument as a result. It is resolved once for the whole frame now, so a per cell coordinate is no longer meaningful, and no preset ever varied on it (all three took it as _). Better to drop it than to keep passing a value that silently only describes the first cell.

Also hoists the two getCoordinates calls off the per frame path: each one read getBoundingClientRect, so the pattern forced two layout reads a frame. The canvas fills the viewport, so the rect only moves on a resize, which is already watched.