### PR TITLE
polish: sets disambiguation tooltip now renders latex instead of string

### DIFF
--- a/packages/magic-products/src/sets/sets/components/HighlightRow.vue
+++ b/packages/magic-products/src/sets/sets/components/HighlightRow.vue
@@ -11,6 +11,7 @@
   import { LATEX_HOTKEYS } from '../other/constants.ts';
   import LatexInput from './latex-input/LatexInput.vue';
   import type { LatexInputInstance } from './latex-input/types.ts';
+  import LatexText from './LatexText.vue';
 
   const props = defineProps<{
     queryId: HighlightQueryId;
@@ -93,6 +94,8 @@
         <!-- TODO replace with a proper icon button -->
         <Button @click="applyDisambiguation">&#9432;</Button>
       </template>
+      Ambiguous order of operations. Parsed as:
+      <LatexText>{{ disambiguated }}</LatexText>
     </Tooltip>
 
     <Tooltip

--- a/packages/magic-products/src/sets/sets/components/LatexText.vue
+++ b/packages/magic-products/src/sets/sets/components/LatexText.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+  import { nullThrows } from '@core/utils/assert';
+  import katex from 'katex';
+
+  import { onMounted, ref } from 'vue';
+
+  const textContent = ref<HTMLSpanElement>();
+  const hasRendered = ref(false);
+
+  defineSlots<{
+    default: () => unknown;
+  }>();
+
+  onMounted(() => {
+    const element = nullThrows(
+      textContent.value,
+      'latex text content DOM element missing',
+    );
+
+    katex.render(element.textContent?.trim() ?? '', element, {
+      throwOnError: false,
+    });
+    hasRendered.value = true;
+  });
+</script>
+
+<template>
+  <span
+    ref="textContent"
+    :class="hasRendered ? undefined : 'invisible'"
+    ><slot
+  /></span>
+</template>


### PR DESCRIPTION
previously rendered a latex string instead of actual latex. This was commented out during the move from sets repo and got lost. Re-implemented.