### PR TITLE
fix(graph/plugins): marquee drag box sets a crosshair cursor

### DIFF
--- a/packages/graph-plugins/src/marquee/constants.ts
+++ b/packages/graph-plugins/src/marquee/constants.ts
@@ -1,3 +1,6 @@
 export const MARQUEE_SHAPE_ID = 'marquee-box';
 
 export const MARQUEE_PLUGIN_ID = 'plugins/marquee';
+
+/** floor for a collapsed drag box, since the border width is themeable to zero */
+export const MIN_MARQUEE_EXTENT = 1;

--- a/packages/graph-plugins/src/marquee/createCursorThemer.ts
+++ b/packages/graph-plugins/src/marquee/createCursorThemer.ts
@@ -1,0 +1,34 @@
+import { ThemeController } from '@core/themes/index';
+import { PluginOptions } from '@graph/plugins-shared/plugins';
+
+import { MARQUEE_PLUGIN_ID } from './constants.ts';
+import { MarqueeThemes } from './themes.ts';
+import { MarqueePlugin } from './types.ts';
+
+const layerId = `${MARQUEE_PLUGIN_ID}/createCursorThemer`;
+
+export const createCursorThemer = (
+  controls: PluginOptions<MarqueePlugin>['controls'],
+  theme: ThemeController<MarqueeThemes>,
+  isDragging: () => boolean,
+) => {
+  // canvas.cursor, not element data: the pointer rides the box's corner, right on
+  // the hit test boundary
+  const canvas = controls.surface.theme.createLayer(layerId);
+
+  const dragCursor = () =>
+    isDragging() ? theme._resolveToken('marquee.drag.cursor') : undefined;
+
+  const enable = () => {
+    canvas.set('canvas.cursor', dragCursor);
+  };
+
+  const disable = () => {
+    canvas.removeAll();
+  };
+
+  return {
+    enable,
+    disable,
+  };
+};

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -12,7 +12,11 @@ import { ANCHOR_PLUGIN_ID } from '../anchors/constants.ts';
 import { NODE_DRAG_CANVAS_ELEMENT_DATA_FIELD } from '../node-drag/constants.ts';
 import { CANVAS_ELEMENT_CURSOR_FIELD_KEY } from '../surface/setupCursor.ts';
 import { GraphUnderCursor } from '../surface/types.ts';
-import { MARQUEE_PLUGIN_ID, MARQUEE_SHAPE_ID } from './constants.ts';
+import {
+  MARQUEE_PLUGIN_ID,
+  MARQUEE_SHAPE_ID,
+  MIN_MARQUEE_EXTENT,
+} from './constants.ts';
 import { createMarqueeEventRegistry } from './events.ts';
 import { getSelectionBox, getSurfaceArea } from './helpers.ts';
 import { createMarqueeThemeOverrides } from './themes.ts';
@@ -24,19 +28,17 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
 
   const theme = createThemeController(createMarqueeThemeOverrides());
 
-  /*
-    the drag box is an unreliable place to hang a cursor: the pointer rides its
-    moving corner, where the boundary hit test is a coin flip, and while width or
-    height is still zero there is no element in the aggregator to carry one at
-    all. canvas.cursor resolves ahead of the element lookup, so it holds for the
-    whole drag regardless
-  */
+  // canvas.cursor, not element data: the pointer rides the box's corner, right on
+  // the hit test boundary
   const cursorLayer = controls.surface.theme.createLayer(
     `${MARQUEE_PLUGIN_ID}/cursor`,
   );
 
   let marqueeBox: BoundingBox | undefined = undefined;
   let selectionBox: BoundingBox | undefined = undefined;
+
+  // latched, not live: a drag back to its own origin is zero sized again
+  let marqueeBoxHasMoved = false;
 
   /**
    * given a mouse event, engages or disengages the marquee box
@@ -56,6 +58,7 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
       width: 0,
       height: 0,
     };
+    marqueeBoxHasMoved = false;
     marqueeEventHub.emit('onMarqueeBeginSelection', startingCoords);
   };
 
@@ -63,6 +66,7 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     if (!marqueeBox) return;
     const finalMarqueeBox = marqueeBox;
     marqueeBox = undefined;
+    marqueeBoxHasMoved = false;
     marqueeEventHub.emit('onMarqueeEndSelection', finalMarqueeBox);
   };
 
@@ -99,17 +103,28 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     const { x, y } = coords;
     marqueeBox.width = x - marqueeBox.at.x;
     marqueeBox.height = y - marqueeBox.at.y;
+
+    if (marqueeBox.width !== 0 || marqueeBox.height !== 0) {
+      marqueeBoxHasMoved = true;
+    }
+
     updateMarqueeSelectedItems(marqueeBox);
   };
 
   const getMarqueeBoxCanvasElement = (box: BoundingBox): CanvasElement => {
+    const { at, width, height } = normalizeBoundingBox(box);
+    const borderWidth = theme._resolveToken('marquee.drag.border.width');
+
     const shape = controls.surface.shapes.rect({
       id: MARQUEE_SHAPE_ID,
-      ...normalizeBoundingBox(box),
+      at,
+      // a zero extent paints nothing, so a dead straight drag collapses to a line
+      width: Math.max(width, borderWidth || MIN_MARQUEE_EXTENT),
+      height: Math.max(height, borderWidth || MIN_MARQUEE_EXTENT),
       fillColor: theme._resolveToken('marquee.drag.color'),
       stroke: {
         color: theme._resolveToken('marquee.drag.border.color'),
-        lineWidth: theme._resolveToken('marquee.drag.border.width'),
+        lineWidth: borderWidth,
       },
     });
 
@@ -120,22 +135,10 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     };
   };
 
-  /*
-    mousedown engages the box before the pointer has moved, so an engaged box is
-    not yet a drag. either axis alone counts: a dead straight drag leaves the
-    other at zero, and requiring both would drop the cursor mid gesture
-  */
-  const hasMarqueeBoxMoved = () =>
-    !!marqueeBox && (marqueeBox.width !== 0 || marqueeBox.height !== 0);
-
   const addMarqueeBoxToAggregator = (aggregator: Aggregator) => {
-    if (!marqueeBox) return aggregator;
+    if (!marqueeBox || !marqueeBoxHasMoved) return aggregator;
 
-    const { width, height } = marqueeBox;
-    if (width === 0 || height === 0) return aggregator;
-
-    const selectionBoxCanvasElement = getMarqueeBoxCanvasElement(marqueeBox);
-    aggregator.push(selectionBoxCanvasElement);
+    aggregator.push(getMarqueeBoxCanvasElement(marqueeBox));
     return aggregator;
   };
 
@@ -194,7 +197,7 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
 
   const onEnable = () => {
     cursorLayer.set('canvas.cursor', () =>
-      hasMarqueeBoxMoved()
+      marqueeBoxHasMoved
         ? theme._resolveToken('marquee.drag.cursor')
         : undefined,
     );

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -17,6 +17,7 @@ import {
   MARQUEE_SHAPE_ID,
   MIN_MARQUEE_EXTENT,
 } from './constants.ts';
+import { createCursorThemer } from './createCursorThemer.ts';
 import { createMarqueeEventRegistry } from './events.ts';
 import { getSelectionBox, getSurfaceArea } from './helpers.ts';
 import { createMarqueeThemeOverrides } from './themes.ts';
@@ -27,12 +28,6 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
   const marqueeEventHub = createEventHub(marqueeEventRegistry);
 
   const theme = createThemeController(createMarqueeThemeOverrides());
-
-  // canvas.cursor, not element data: the pointer rides the box's corner, right on
-  // the hit test boundary
-  const cursorLayer = controls.surface.theme.createLayer(
-    `${MARQUEE_PLUGIN_ID}/cursor`,
-  );
 
   let marqueeBox: BoundingBox | undefined = undefined;
   let selectionBox: BoundingBox | undefined = undefined;
@@ -195,12 +190,14 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
   controls.surface.aggregator.transformers.push(addSelectionBoxToAggregator);
   controls.surface.aggregator.transformers.push(addMarqueeBoxToAggregator);
 
+  const cursorTheme = createCursorThemer(
+    controls,
+    theme,
+    () => marqueeBoxHasMoved,
+  );
+
   const onEnable = () => {
-    cursorLayer.set('canvas.cursor', () =>
-      marqueeBoxHasMoved
-        ? theme._resolveToken('marquee.drag.cursor')
-        : undefined,
-    );
+    cursorTheme.enable();
 
     controls.focus.events.subscribe('onFocusChange', updateSelectionBox);
 
@@ -251,7 +248,7 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     events._internal.core.unsubscribe('onNodeMoveStream', updateSelectionBox);
 
     disengageMarqueeBox();
-    cursorLayer.removeAll();
+    cursorTheme.disable();
   };
 
   const lifecycle = createLifecycle({

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -24,6 +24,17 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
 
   const theme = createThemeController(createMarqueeThemeOverrides());
 
+  /*
+    the drag box is an unreliable place to hang a cursor: the pointer rides its
+    moving corner, where the boundary hit test is a coin flip, and while width or
+    height is still zero there is no element in the aggregator to carry one at
+    all. canvas.cursor resolves ahead of the element lookup, so it holds for the
+    whole drag regardless
+  */
+  const cursorLayer = controls.surface.theme.createLayer(
+    `${MARQUEE_PLUGIN_ID}/cursor`,
+  );
+
   let marqueeBox: BoundingBox | undefined = undefined;
   let selectionBox: BoundingBox | undefined = undefined;
 
@@ -109,6 +120,14 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     };
   };
 
+  /*
+    mousedown engages the box before the pointer has moved, so an engaged box is
+    not yet a drag. either axis alone counts: a dead straight drag leaves the
+    other at zero, and requiring both would drop the cursor mid gesture
+  */
+  const hasMarqueeBoxMoved = () =>
+    !!marqueeBox && (marqueeBox.width !== 0 || marqueeBox.height !== 0);
+
   const addMarqueeBoxToAggregator = (aggregator: Aggregator) => {
     if (!marqueeBox) return aggregator;
 
@@ -174,6 +193,12 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
   controls.surface.aggregator.transformers.push(addMarqueeBoxToAggregator);
 
   const onEnable = () => {
+    cursorLayer.set('canvas.cursor', () =>
+      hasMarqueeBoxMoved()
+        ? theme._resolveToken('marquee.drag.cursor')
+        : undefined,
+    );
+
     controls.focus.events.subscribe('onFocusChange', updateSelectionBox);
 
     controls.surface.events.elements.handle(
@@ -223,6 +248,7 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     events._internal.core.unsubscribe('onNodeMoveStream', updateSelectionBox);
 
     disengageMarqueeBox();
+    cursorLayer.removeAll();
   };
 
   const lifecycle = createLifecycle({

--- a/packages/graph-plugins/src/marquee/themes.ts
+++ b/packages/graph-plugins/src/marquee/themes.ts
@@ -6,6 +6,7 @@ export type MarqueeThemes = {
   'marquee.drag.color': ThemeValue<Color>;
   'marquee.drag.border.color': ThemeValue<Color>;
   'marquee.drag.border.width': ThemeValue<number>;
+  'marquee.drag.cursor': ThemeValue<Cursor | CursorFallback>;
   'marquee.selection.color': ThemeValue<Color>;
   'marquee.selection.border.color': ThemeValue<Color>;
   'marquee.selection.border.width': ThemeValue<number>;
@@ -17,6 +18,7 @@ export const createMarqueeThemeOverrides =
     'marquee.drag.color': [],
     'marquee.drag.border.color': [],
     'marquee.drag.border.width': [],
+    'marquee.drag.cursor': [],
     'marquee.selection.color': [],
     'marquee.selection.border.color': [],
     'marquee.selection.border.width': [],

--- a/packages/graph-theme-presets/src/dark/index.ts
+++ b/packages/graph-theme-presets/src/dark/index.ts
@@ -82,6 +82,7 @@ export const dark = {
     'marquee.drag.border.color': colors.WHITE,
     'marquee.drag.border.width': 1,
     'marquee.drag.color': colors.WHITE + '15',
+    'marquee.drag.cursor': CURSOR.CROSSHAIR,
 
     'marquee.selection.border.color': colors.RED_700,
     'marquee.selection.border.width': 1,

--- a/packages/graph-theme-presets/src/light/index.ts
+++ b/packages/graph-theme-presets/src/light/index.ts
@@ -82,6 +82,7 @@ export const light = {
     'marquee.drag.border.color': colors.BLUE_500,
     'marquee.drag.border.width': 1,
     'marquee.drag.color': colors.BLUE_300 + '15',
+    'marquee.drag.cursor': CURSOR.CROSSHAIR,
 
     'marquee.selection.border.color': colors.BLUE_700,
     'marquee.selection.border.width': 1,

--- a/packages/graph-theme-presets/src/pink/index.ts
+++ b/packages/graph-theme-presets/src/pink/index.ts
@@ -82,6 +82,7 @@ export const pink = {
     'marquee.drag.border.color': colors.PINK_500,
     'marquee.drag.border.width': 1,
     'marquee.drag.color': colors.PINK_300 + '15',
+    'marquee.drag.cursor': CURSOR.CROSSHAIR,
 
     'marquee.selection.border.color': colors.PINK_700,
     'marquee.selection.border.width': 1,


### PR DESCRIPTION
The drag box carries no cursor data, so `setupCursor` fell through to `CURSOR.DEFAULT`.

Adds a `marquee.drag.cursor` token (`CROSSHAIR` in all presets) driven from a `canvas.cursor` layer, keyed on `marqueeBox` and following `createDragThemer`.


Closes #816