### PR TITLE
refactor(canvas-primitives): expose addTransformer/removeTransformer on the aggregator

### DIFF
--- a/packages/canvas-primitives/src/aggregator/index.test.ts
+++ b/packages/canvas-primitives/src/aggregator/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAggregator } from './index.ts';
+import { Aggregator, AggregatorTransformer, CanvasElement } from './types.ts';
+
+const rendererStub = {
+  beginFrame: () => {},
+  endFrame: () => {},
+  drawGroup: () => {},
+};
+
+const element = (id: string, priority = 0) =>
+  ({ id, priority, shape: {} }) as unknown as CanvasElement;
+
+const pushing =
+  (id: string, priority = 0): AggregatorTransformer =>
+  (agg: Aggregator) => {
+    agg.push(element(id, priority));
+    return agg;
+  };
+
+const setup = () => {
+  const controls = createAggregator(rendererStub);
+  const draw = () => {
+    controls.draw({} as CanvasRenderingContext2D);
+    return controls.aggregator().map(({ id }) => id);
+  };
+  return { ...controls, draw };
+};
+
+describe('addTransformer', () => {
+  it('runs registered transformers in registration order', () => {
+    const { addTransformer, draw } = setup();
+
+    addTransformer(pushing('a'));
+    addTransformer(pushing('b'));
+
+    expect(draw()).toEqual(['a', 'b']);
+  });
+});
+
+describe('removeTransformer', () => {
+  it('stops running a removed transformer', () => {
+    const { addTransformer, removeTransformer, draw } = setup();
+    const transformer = pushing('a');
+
+    addTransformer(transformer);
+    addTransformer(pushing('b'));
+    removeTransformer(transformer);
+
+    expect(draw()).toEqual(['b']);
+  });
+
+  it('leaves the order of the remaining transformers untouched', () => {
+    const { addTransformer, removeTransformer, draw } = setup();
+    const transformer = pushing('b');
+
+    addTransformer(pushing('a'));
+    addTransformer(transformer);
+    addTransformer(pushing('c'));
+    removeTransformer(transformer);
+
+    expect(draw()).toEqual(['a', 'c']);
+  });
+
+  it('is a no-op for a transformer that was never added', () => {
+    const { addTransformer, removeTransformer, draw } = setup();
+
+    addTransformer(pushing('a'));
+    removeTransformer(pushing('b'));
+
+    expect(draw()).toEqual(['a']);
+  });
+});

--- a/packages/canvas-primitives/src/aggregator/index.test.ts
+++ b/packages/canvas-primitives/src/aggregator/index.test.ts
@@ -37,6 +37,16 @@ describe('addTransformer', () => {
 
     expect(draw()).toEqual(['a', 'b']);
   });
+
+  it('threads the array a transformer returns into the next one', () => {
+    const { addTransformer, draw } = setup();
+
+    addTransformer(pushing('a'));
+    addTransformer(pushing('b'));
+    addTransformer((agg) => agg.filter(({ id }) => id !== 'a'));
+
+    expect(draw()).toEqual(['b']);
+  });
 });
 
 describe('removeTransformer', () => {
@@ -69,6 +79,32 @@ describe('removeTransformer', () => {
     addTransformer(pushing('a'));
     removeTransformer(pushing('b'));
 
+    expect(draw()).toEqual(['a']);
+  });
+
+  it('removes a single registration of a transformer added twice', () => {
+    const { addTransformer, removeTransformer, draw } = setup();
+    const transformer = pushing('a');
+
+    addTransformer(transformer);
+    addTransformer(transformer);
+    removeTransformer(transformer);
+
+    expect(draw()).toEqual(['a']);
+  });
+
+  it('leaves the in flight pass untouched when a transformer removes another', () => {
+    const { addTransformer, removeTransformer, draw } = setup();
+    const last = pushing('c');
+
+    addTransformer(pushing('a'));
+    addTransformer((agg) => {
+      removeTransformer(last);
+      return agg;
+    });
+    addTransformer(last);
+
+    expect(draw()).toEqual(['a', 'c']);
     expect(draw()).toEqual(['a']);
   });
 });

--- a/packages/canvas-primitives/src/aggregator/index.ts
+++ b/packages/canvas-primitives/src/aggregator/index.ts
@@ -8,8 +8,24 @@ import { Aggregator, AggregatorTransformer, CanvasElement } from './types.ts';
 
 export type AggregatorControls = {
   aggregator: () => DeepReadonly<Aggregator>;
-  transformers: AggregatorTransformer[];
-  updateAggregator: () => void;
+  /**
+   * registers a {@link AggregatorTransformer | transformer} to run each render cycle
+   *
+   * ℹ️ transformers run in registration order, each handed the aggregator the previous
+   * one returned
+   *
+   * @param fn the transformer to add
+   * @example addTransformer((agg) => { agg.push(myElement); return agg })
+   */
+  addTransformer: (fn: AggregatorTransformer) => void;
+  /**
+   * unregisters a {@link AggregatorTransformer | transformer}, leaving the order of the
+   * remaining ones untouched. a no-op if it was never added
+   *
+   * @param fn the same function reference that was handed to {@link AggregatorControls.addTransformer | addTransformer}
+   * @example removeTransformer(myTransformer)
+   */
+  removeTransformer: (fn: AggregatorTransformer) => void;
   getCanvasElementsAtCoordinate: (coords: Coordinate) => CanvasElement[];
   draw: (ctx: CanvasRenderingContext2D) => void;
   events: ReadonlyEventHub<AggregatorEventMap>;
@@ -32,6 +48,15 @@ export const createAggregator = (
     aggregator = resolvedCanvasElements.toSorted(
       (a, b) => a.priority - b.priority,
     );
+  };
+
+  const addTransformer = (fn: AggregatorTransformer) => {
+    transformers.push(fn);
+  };
+
+  const removeTransformer = (fn: AggregatorTransformer) => {
+    const index = transformers.indexOf(fn);
+    if (index !== -1) transformers.splice(index, 1);
   };
 
   const groupByPriority = (elements: Aggregator): Map<number, Aggregator> => {
@@ -76,8 +101,8 @@ export const createAggregator = (
 
   return {
     aggregator: () => aggregator,
-    transformers,
-    updateAggregator,
+    addTransformer,
+    removeTransformer,
     getCanvasElementsAtCoordinate,
     draw,
     events,

--- a/packages/canvas-primitives/src/aggregator/index.ts
+++ b/packages/canvas-primitives/src/aggregator/index.ts
@@ -22,6 +22,8 @@ export type AggregatorControls = {
    * unregisters a {@link AggregatorTransformer | transformer}, leaving the order of the
    * remaining ones untouched. a no-op if it was never added
    *
+   * ℹ️ removes a single registration, so a transformer added twice must be removed twice
+   *
    * @param fn the same function reference that was handed to {@link AggregatorControls.addTransformer | addTransformer}
    * @example removeTransformer(myTransformer)
    */
@@ -40,7 +42,9 @@ export const createAggregator = (
   const transformers: AggregatorTransformer[] = [];
 
   const updateAggregator = () => {
-    const resolvedCanvasElements = transformers.reduce<Aggregator>(
+    // snapshot: a transformer that adds or removes one mid pass would otherwise
+    // shift the indicies out from under the reduce
+    const resolvedCanvasElements = [...transformers].reduce<Aggregator>(
       (acc, fn) => fn(acc),
       [],
     );

--- a/packages/graph-create-graph/src/index.ts
+++ b/packages/graph-create-graph/src/index.ts
@@ -102,15 +102,13 @@ export const createGraph = <
   // could be built (see [5] in plugins/internals/plugin.ts)
   folded.resolveFinalRenderFunctions(renderFunctions);
 
-  const { transformers } = castControls.surface.aggregator;
-
   const transformer: AggregatorTransformer = (agg) => {
     agg.push(...controls.nodes().map(nodeCanvasElement));
     agg.push(...controls.edges().map(edgeCanvasElement));
     return agg;
   };
 
-  transformers.push(transformer);
+  castControls.surface.aggregator.addTransformer(transformer);
 
   type GraphTransitControls = GraphTransit<
     Prettify<ExtractTransitPayload<NoInfer<TPlugins>>>

--- a/packages/graph-create-graph/src/phantom.test.ts
+++ b/packages/graph-create-graph/src/phantom.test.ts
@@ -15,7 +15,9 @@ import { createGraphTransit } from './graph-transit.ts';
 const createSurfaceStub = (transformers: AggregatorTransformer[]) => () => ({
   name: 'surface',
   controls: {
-    aggregator: { transformers },
+    aggregator: {
+      addTransformer: (fn: AggregatorTransformer) => transformers.push(fn),
+    },
     theme: createThemeController(createSurfaceThemeOverrides()),
   },
 });

--- a/packages/graph-plugins/src/anchors/index.ts
+++ b/packages/graph-plugins/src/anchors/index.ts
@@ -321,10 +321,8 @@ export const anchors: AnchorsPlugin = ({ controls, events, getters }) => {
     return aggregator;
   };
 
-  controls.surface.aggregator.transformers.push(insertAnchorsIntoAggregator);
-  controls.surface.aggregator.transformers.push(
-    insertLinkPreviewIntoAggregator,
-  );
+  controls.surface.aggregator.addTransformer(insertAnchorsIntoAggregator);
+  controls.surface.aggregator.addTransformer(insertLinkPreviewIntoAggregator);
 
   const consumeOnElementHoverEvent = (
     _: DeepReadonly<CanvasElement> | undefined,

--- a/packages/graph-plugins/src/annotations/index.ts
+++ b/packages/graph-plugins/src/annotations/index.ts
@@ -69,7 +69,7 @@ export const annotations: AnnotationsPlugin = ({ controls }) => {
     return aggregator;
   };
 
-  controls.surface.aggregator.transformers.push(addAnnotationsToAggregator);
+  controls.surface.aggregator.addTransformer(addAnnotationsToAggregator);
 
   const captureSnapshot = () => controls.history?.captureSnapshot();
 

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -170,8 +170,8 @@ export const marquee: MarqueePlugin = ({ controls, events }) => {
     return aggregator;
   };
 
-  controls.surface.aggregator.transformers.push(addSelectionBoxToAggregator);
-  controls.surface.aggregator.transformers.push(addMarqueeBoxToAggregator);
+  controls.surface.aggregator.addTransformer(addSelectionBoxToAggregator);
+  controls.surface.aggregator.addTransformer(addMarqueeBoxToAggregator);
 
   const onEnable = () => {
     controls.focus.events.subscribe('onFocusChange', updateSelectionBox);

--- a/packages/graph-plugins/src/phantom/index.ts
+++ b/packages/graph-plugins/src/phantom/index.ts
@@ -77,7 +77,7 @@ export const phantom: PhantomPlugin = ({
   );
   labelThemer.enable();
 
-  controls.surface.aggregator.transformers.push(render);
+  controls.surface.aggregator.addTransformer(render);
 
   const addNode = (node: PhantomNode) => {
     nodes.push(node);

--- a/packages/magic-products/src/min-spanning-trees/chips/allMsts.ts
+++ b/packages/magic-products/src/min-spanning-trees/chips/allMsts.ts
@@ -54,7 +54,7 @@ export const allMstsChip = (graph: Graph): LensChipDefinition => {
     if (!removeEdges) return agg;
     return agg.filter((el) => !graph.isEdge(el.id));
   };
-  graph.surface.aggregator.transformers.push(removeNonPhantomEdges);
+  graph.surface.aggregator.addTransformer(removeNonPhantomEdges);
 
   const mstIndexToColor = (mstIndex: number) =>
     MST_COLORS[mstIndex % MST_COLORS.length];

--- a/packages/magic-shared/src/multiplayer/usePeerDrags.test.ts
+++ b/packages/magic-shared/src/multiplayer/usePeerDrags.test.ts
@@ -30,7 +30,9 @@ const setup = (peerDrags: Record<string, DraggedElement[]> = {}) => {
 
   const transformers: AggregatorTransformer[] = [];
   const surface = {
-    aggregator: { transformers },
+    aggregator: {
+      addTransformer: (fn: AggregatorTransformer) => transformers.push(fn),
+    },
   } as unknown as CanvasSurface;
 
   const applied: string[] = [];

--- a/packages/magic-shared/src/multiplayer/usePeerDrags.ts
+++ b/packages/magic-shared/src/multiplayer/usePeerDrags.ts
@@ -102,5 +102,5 @@ export const usePeerDrags = ({
     return aggregator;
   };
 
-  surface.aggregator.transformers.push(markPeerHeldElements);
+  surface.aggregator.addTransformer(markPeerHeldElements);
 };

--- a/packages/magic-shared/src/product/useMagicProduct.ts
+++ b/packages/magic-shared/src/product/useMagicProduct.ts
@@ -133,7 +133,7 @@ export const useMagicProduct = (
   };
 
   if (multiplayer) {
-    magic.surface.aggregator.transformers.push(nameTagElement);
+    magic.surface.aggregator.addTransformer(nameTagElement);
   }
 
   if (magic.lensChips) {


### PR DESCRIPTION
Closes #639

`transformers` and `updateAggregator` were public, so a consumer could reorder the pipeline or force a sync mid frame. Both are closure local now, replaced by `addTransformer` / `removeTransformer` with JSDoc.

### Public surface

```mermaid
flowchart TB
  subgraph before["before"]
    direction TB
    A1["aggregator()"]
    A2["transformers"]:::leak
    A3["updateAggregator"]:::leak
    A4["getCanvasElementsAtCoordinate()"]
    A5["draw() / events"]
  end
  subgraph after["after"]
    direction TB
    B1["aggregator()"]
    B2["addTransformer(fn)"]
    B3["removeTransformer(fn)"]
    B4["getCanvasElementsAtCoordinate()"]
    B5["draw() / events"]
    B6("transformers"):::hidden
    B7("updateAggregator"):::hidden
  end
  before --> after
  classDef leak fill:#ffdddd,stroke:#cc0000,color:#1a1a1a
  classDef hidden fill:#eeeeee,stroke:#999999,stroke-dasharray:3 3,color:#1a1a1a
```

Dashed nodes are still there, just no longer reachable from outside the closure. `updateAggregator` is called by `draw` as before.

### Draw cycle, unchanged

```mermaid
sequenceDiagram
  participant P as plugin
  participant A as aggregator
  participant R as renderer
  P->>A: addTransformer(fn)
  Note over A: registration order preserved
  R->>A: draw(ctx)
  A->>A: transformers.reduce(...)
  A->>A: sort by priority
  A->>R: drawGroup per priority band
```

`removeTransformer` splices by `indexOf`, so the order of the remaining transformers is untouched and an unknown function is a no op. It removes a single registration, so a transformer added twice must be removed twice.

The reduce runs over a snapshot of the array. Without it, a transformer that unregisters another mid pass shifts the indicies out from under `reduce`, which caches its length up front, silently skipping every transformer after the removed one for that frame.

All 10 existing registrations across `graph-create-graph`, `graph-plugins` (anchors, marquee, phantom, annotations), `magic-shared`, and `magic-products` swap a `transformers.push` for an `addTransformer` call. Two test stubs (`phantom.test.ts`, `usePeerDrags.test.ts`) faked `aggregator: { transformers }` and now expose `addTransformer` instead.

### Tests

New `aggregator/index.test.ts`, 7 tests: registration order, return value threading, removal, order preservation after removal, the no op case, double registration, and removal mid pass. `removeTransformer` has no production caller yet, so it would otherwise ship unexercised.

Typecheck clean, 797 tests passing, prettier clean.

### Notes

The issue's third bullet, "aggregator is a raw Vue ref", is stale. Current code is a plain `let` behind an `aggregator()` getter returning `DeepReadonly`, so there is no ref to hide.

No plugin calls `removeTransformer`. Every plugin registers at setup and never unregisters, guarding with early returns instead, so a disabled plugin's transformer still runs each frame. Wiring `onDisable` to remove is a behavior change and left out of scope.

Touches `marquee/index.ts` on lines near #946, so whichever merges second may need a trivial rebase.
