### PR TITLE
feat(product/shell): add max payload check to link share url

### DIFF
--- a/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
+++ b/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
@@ -17,7 +17,7 @@
   const copyLinkToClipboard = async () => {
     const result = getLink(shell);
 
-    if (!result.ok) {
+    if (!result.success) {
       toast.show({
         title: 'Could Not Make A Link',
         description: result.reason,

--- a/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
+++ b/packages/magic-shared/src/ui/link-sharing/LinkSharingButton.vue
@@ -11,12 +11,24 @@
 
   const COPIED_TOAST_MS = 4_000;
 
-  const COPY_FAILED_TOAST_MS = 6_000;
+  const PROBLEM_TOAST_MS = 6_000;
 
   // awaited, because a clipboard the browser turns down rejects rather than throwing
   const copyLinkToClipboard = async () => {
+    const result = getLink(shell);
+
+    if (!result.ok) {
+      toast.show({
+        title: 'Could Not Make A Link',
+        description: result.reason,
+        severity: 'warn',
+        duration: PROBLEM_TOAST_MS,
+      });
+      return;
+    }
+
     try {
-      await navigator.clipboard.writeText(getLink(shell));
+      await navigator.clipboard.writeText(result.link);
       toast.show({
         title: 'Link Copied',
         description: 'The link carries a copy of what is on screen.',
@@ -29,7 +41,7 @@
         title: 'Could Not Copy The Link',
         description: 'Your browser turned down access to the clipboard.',
         severity: 'error',
-        duration: COPY_FAILED_TOAST_MS,
+        duration: PROBLEM_TOAST_MS,
       });
     }
   };

--- a/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
+++ b/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
@@ -9,6 +9,8 @@ import { queryParam, stripQueryParam } from '../../url/index.ts';
 
 const sharePayloadQueryParam = 'data';
 
+const MAX_PAYLOAD_CHARS = 2_600;
+
 // both sides are unreachable without transit, which is what gates the linkSharing flag
 const transitOf = (shell: Shell) =>
   nullThrows(shell.transit, 'link sharing requires host transit');
@@ -19,13 +21,24 @@ const getLinkPayload = (shell: Shell) => {
   return compressToEncodedURIComponent(stringEncoding);
 };
 
-export const getLink = (shell: Shell) => {
+/** a link, or why what is on screen could not become one */
+export type LinkResult =
+  { ok: true; link: string } | { ok: false; reason: string };
+
+export const getLink = (shell: Shell): LinkResult => {
   const { origin } = window.location;
   const { slug } = shell.manifest.navigation;
   const payload = getLinkPayload(shell);
+
+  if (payload.length > MAX_PAYLOAD_CHARS)
+    return {
+      ok: false,
+      reason: 'There is too much on screen to fit into a link.',
+    };
+
   const query = `${sharePayloadQueryParam}=${payload}`;
 
-  return `${origin}/${slug}?${query}`;
+  return { ok: true, link: `${origin}/${slug}?${query}` };
 };
 
 export const loadFromLinkPayload = (shell: Shell) => {

--- a/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
+++ b/packages/magic-shared/src/ui/link-sharing/linkPayload.ts
@@ -21,9 +21,8 @@ const getLinkPayload = (shell: Shell) => {
   return compressToEncodedURIComponent(stringEncoding);
 };
 
-/** a link, or why what is on screen could not become one */
 export type LinkResult =
-  { ok: true; link: string } | { ok: false; reason: string };
+  { success: true; link: string } | { success: false; reason: string };
 
 export const getLink = (shell: Shell): LinkResult => {
   const { origin } = window.location;
@@ -32,13 +31,13 @@ export const getLink = (shell: Shell): LinkResult => {
 
   if (payload.length > MAX_PAYLOAD_CHARS)
     return {
-      ok: false,
+      success: false,
       reason: 'There is too much on screen to fit into a link.',
     };
 
   const query = `${sharePayloadQueryParam}=${payload}`;
 
-  return { ok: true, link: `${origin}/${slug}?${query}` };
+  return { success: true, link: `${origin}/${slug}?${query}` };
 };
 
 export const loadFromLinkPayload = (shell: Shell) => {


### PR DESCRIPTION
fixes #832 

measured against the compressed payload rather than a node count, because that is the thing that actually has to fit. a sparse graph and a dense one of the same size are nowhere near the same length once encoded. additionally, rounding the node positions even to 1px would save a lot of encoding data, right now I think they are encoded with lots of extra precision.

