### PR TITLE
refactor(product/sets): add mutation API and events

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
     "toastservice",
     "topo",
     "trackpad",
+    "travelled",
     "trivago",
     "tweens",
     "undrawn",

--- a/packages/core-annotations/src/createAnnotations.test.ts
+++ b/packages/core-annotations/src/createAnnotations.test.ts
@@ -57,7 +57,7 @@ describe('annotations', () => {
     ]);
     expect(annotation.fillColor).toBe('#ff0000');
     expect(annotation.brushWeight).toBe(9);
-    expect(changes).toEqual([{ added: [annotation], removedIds: [] }]);
+    expect(changes).toEqual([{ added: [annotation], removed: [] }]);
   });
 
   it('leaves nothing behind for a laser stroke', () => {
@@ -82,7 +82,7 @@ describe('annotations', () => {
     annotations.endStroke();
 
     expect(annotations.annotations()).toEqual([untouched]);
-    expect(changes).toEqual([{ added: [], removedIds: [erased.id] }]);
+    expect(changes).toEqual([{ added: [], removed: [erased] }]);
   });
 
   it('reports only what actually changed when the whole set is written', () => {
@@ -94,7 +94,7 @@ describe('annotations', () => {
 
     annotations.setAll([kept, arriving]);
 
-    expect(changes).toEqual([{ added: [arriving], removedIds: [] }]);
+    expect(changes).toEqual([{ added: [arriving], removed: [] }]);
     expect(annotations.annotations()).toEqual([kept, arriving]);
   });
 

--- a/packages/core-annotations/src/createAnnotations.ts
+++ b/packages/core-annotations/src/createAnnotations.ts
@@ -60,9 +60,20 @@ export const createAnnotations = ({
   const isErasing = () => mode() === 'erasing';
   const isLaserPointing = () => mode() === 'laser';
 
-  const emitChange = (added: Annotation[], removedIds: string[]) => {
-    if (added.length === 0 && removedIds.length === 0) return;
-    events.emit('onAnnotationsChanged', { added, removedIds });
+  const emitChange = (added: Annotation[], removed: Annotation[]) => {
+    if (added.length === 0 && removed.length === 0) return;
+    events.emit('onAnnotationsChanged', { added, removed });
+  };
+
+  const takeAll = (ids: Iterable<string>) => {
+    const taken: Annotation[] = [];
+    for (const id of ids) {
+      const annotation = annotationsById.get(id);
+      if (!annotation) continue;
+      annotationsById.delete(id);
+      taken.push(annotation);
+    }
+    return taken;
   };
 
   // an annotation never changes once committed, so an id already held is already identical
@@ -74,18 +85,12 @@ export const createAnnotations = ({
     emitChange(added, []);
   };
 
-  const remove = (ids: string[]) => {
-    const removedIds: string[] = [];
-    for (const id of ids) {
-      if (annotationsById.delete(id)) removedIds.push(id);
-    }
-    emitChange([], removedIds);
-  };
+  const remove = (ids: string[]) => emitChange([], takeAll(ids));
 
   const setAll = (next: Annotation[]) => {
     const nextIds = new Set(next.map(({ id }) => id));
-    const removedIds = [...annotationsById.keys()].filter(
-      (id) => !nextIds.has(id),
+    const removed = takeAll(
+      [...annotationsById.keys()].filter((id) => !nextIds.has(id)),
     );
     const added = next.filter(({ id }) => !annotationsById.has(id));
 
@@ -94,14 +99,10 @@ export const createAnnotations = ({
       annotationsById.set(annotation.id, annotation);
     }
 
-    emitChange(added, removedIds);
+    emitChange(added, removed);
   };
 
-  const clear = () => {
-    const removedIds = [...annotationsById.keys()];
-    annotationsById.clear();
-    emitChange([], removedIds);
-  };
+  const clear = () => emitChange([], takeAll([...annotationsById.keys()]));
 
   const markErased = (coords: Coordinate) => {
     const eraserBox = circle({

--- a/packages/core-annotations/src/events.ts
+++ b/packages/core-annotations/src/events.ts
@@ -5,10 +5,6 @@ import type { Annotation, InFlightStroke } from './types.ts';
 
 export type AnnotationsChange = {
   added: Annotation[];
-  /**
-   * the annotations themselves rather than their ids, so a change is enough to undo on
-   * its own: a stroke is only ever added or removed, never edited
-   */
   removed: Annotation[];
 };
 

--- a/packages/core-annotations/src/events.ts
+++ b/packages/core-annotations/src/events.ts
@@ -5,7 +5,11 @@ import type { Annotation, InFlightStroke } from './types.ts';
 
 export type AnnotationsChange = {
   added: Annotation[];
-  removedIds: string[];
+  /**
+   * the annotations themselves rather than their ids, so a change is enough to undo on
+   * its own: a stroke is only ever added or removed, never edited
+   */
+  removed: Annotation[];
 };
 
 export type AnnotationsEventMap = {

--- a/packages/magic-products/package.json
+++ b/packages/magic-products/package.json
@@ -24,6 +24,7 @@
     "@canvas/surface": "workspace:*",
     "@core/annotations": "workspace:*",
     "@core/components": "workspace:*",
+    "@core/events": "workspace:*",
     "@core/themes": "workspace:*",
     "@core/utils": "workspace:*",
     "@cortex-js/compute-engine": "^0.102.0",

--- a/packages/magic-products/src/sets/MainView.vue
+++ b/packages/magic-products/src/sets/MainView.vue
@@ -3,8 +3,6 @@
   import Shell from '@magic/shared/Shell';
   import { toast } from '@magic/shared/toast';
 
-  import { useCircleDrag } from './composables/useCircleDrag.ts';
-  import { useCircleResize } from './composables/useCircleResize.ts';
   import { useSetsRendering } from './composables/useSetsRendering.ts';
   import { INPUT_HANDLER_ID, MAX_SETS } from './constants.ts';
   import { useSetsShell } from './sets-shell/useSetsShell.ts';
@@ -13,14 +11,6 @@
     shell,
     setsState: { sets, sections, queryAnalysis, theme, queries, focus },
   } = useSetsShell();
-
-  useCircleResize({ surface: shell.surface, definitions: sets.definitions });
-
-  useCircleDrag({
-    surface: shell.surface,
-    definitions: sets.definitions,
-    theme,
-  });
 
   useSetsRendering({
     surface: shell.surface,
@@ -65,9 +55,9 @@
 
   const deleteFocusedSetDefinitions = () => {
     const focusedSetIds = sets.definitions.value
-      .map((s) => s.id)
+      .map((definition) => definition.id)
       .filter(focus.isFocused);
-    for (const setId of focusedSetIds) sets.removeDefinition(setId);
+    sets.remove(focusedSetIds);
   };
 
   shell.surface.events.elements.handle(

--- a/packages/magic-products/src/sets/composables/useCircleDrag.ts
+++ b/packages/magic-products/src/sets/composables/useCircleDrag.ts
@@ -1,42 +1,41 @@
 import type { CanvasSurface } from '@canvas/surface/types';
 import { CURSOR } from '@core/utils/cursor';
 
-import { type Ref, onBeforeUnmount } from 'vue';
+import { onBeforeUnmount } from 'vue';
 
 import { INPUT_HANDLER_ID } from '../constants.ts';
 import { setElementIdentity } from '../draw/elementIdentity.ts';
+import type { SetDefinitions } from '../setDefinitions.ts';
 import type { SetsTheme } from '../theme/useSetsTheme.ts';
-import type { SetDefinition } from '../types.ts';
+import type { SetDefinitionId } from '../types.ts';
 import { useDrag } from './useDrag.ts';
 
 const DRAG_THEME_LAYER_ID = 'sets/useCircleDrag';
 
 type CircleDragProps = {
   surface: CanvasSurface;
-  definitions: Ref<SetDefinition[]>;
+  sets: SetDefinitions;
   theme: SetsTheme;
 };
 
-export const useCircleDrag = ({
-  surface,
-  definitions,
-  theme,
-}: CircleDragProps) => {
-  const drag = useDrag(
+export const useCircleDrag = ({ surface, sets, theme }: CircleDragProps) => {
+  const drag = useDrag<SetDefinitionId>({
     surface,
-    INPUT_HANDLER_ID.circleDrag,
-    ({ topElement }) => {
+    handlerId: INPUT_HANDLER_ID.circleDrag,
+
+    // the id rather than the definition, so a set removed mid gesture leaves the drag
+    // moving nothing instead of mutating an orphan
+    getItem: ({ topElement }) => {
       // the resize band sits above the circle, so landing on the edge is not a drag
       const identity = setElementIdentity(topElement);
       if (identity?.part !== 'body') return;
-      return definitions.value.find(({ id }) => id === identity.setId);
+      if (!sets.hasDefinition(identity.setId)) return;
+      return identity.setId;
     },
-    (definition, { diff }) => {
-      const { at } = definition.display;
-      at.x += diff.x;
-      at.y += diff.y;
-    },
-  );
+
+    onMove: (setId, { diff }) => sets.moveDefinition(setId, diff),
+    onDrop: (setId) => sets.commitDisplay([setId]),
+  });
 
   const cursorLayer = theme.createLayer(DRAG_THEME_LAYER_ID);
   cursorLayer.set('canvas.cursor', () =>

--- a/packages/magic-products/src/sets/composables/useCircleDrag.ts
+++ b/packages/magic-products/src/sets/composables/useCircleDrag.ts
@@ -31,7 +31,6 @@ export const useCircleDrag = ({ surface, sets, theme }: CircleDragProps) => {
     },
 
     onMove: (setId, { diff }) => sets.moveDefinition(setId, diff),
-    onDrop: (setId) => sets.commitDisplay([setId]),
   });
 
   const cursorLayer = theme.createLayer(DRAG_THEME_LAYER_ID);

--- a/packages/magic-products/src/sets/composables/useCircleDrag.ts
+++ b/packages/magic-products/src/sets/composables/useCircleDrag.ts
@@ -23,10 +23,7 @@ export const useCircleDrag = ({ surface, sets, theme }: CircleDragProps) => {
     surface,
     handlerId: INPUT_HANDLER_ID.circleDrag,
 
-    // the id rather than the definition, so a set removed mid gesture leaves the drag
-    // moving nothing instead of mutating an orphan
     getItem: ({ topElement }) => {
-      // the resize band sits above the circle, so landing on the edge is not a drag
       const identity = setElementIdentity(topElement);
       if (identity?.part !== 'body') return;
       if (!sets.hasDefinition(identity.setId)) return;

--- a/packages/magic-products/src/sets/composables/useCircleResize.ts
+++ b/packages/magic-products/src/sets/composables/useCircleResize.ts
@@ -31,8 +31,6 @@ export const useCircleResize = ({ surface, sets }: CircleResizeProps) => {
         Math.hypot(at.x - coords.x, at.y - coords.y),
       );
     },
-
-    onDrop: (setId) => sets.commitDisplay([setId]),
   });
 
   return {

--- a/packages/magic-products/src/sets/composables/useCircleResize.ts
+++ b/packages/magic-products/src/sets/composables/useCircleResize.ts
@@ -1,44 +1,40 @@
 import type { CanvasSurface } from '@canvas/surface/types';
 
-import type { Ref } from 'vue';
-
-import {
-  INPUT_HANDLER_ID,
-  MAX_CIRCLE_RADIUS,
-  MIN_CIRCLE_RADIUS,
-} from '../constants.ts';
+import { INPUT_HANDLER_ID } from '../constants.ts';
 import { setElementIdentity } from '../draw/elementIdentity.ts';
-import type { SetDefinition } from '../types.ts';
+import type { SetDefinitions } from '../setDefinitions.ts';
+import type { SetDefinitionId } from '../types.ts';
 import { useDrag } from './useDrag.ts';
 
 type CircleResizeProps = {
   surface: CanvasSurface;
-  definitions: Ref<SetDefinition[]>;
+  sets: SetDefinitions;
 };
 
-export const useCircleResize = ({
-  surface,
-  definitions,
-}: CircleResizeProps) => {
-  const { isDragging: isResizing } = useDrag(
+export const useCircleResize = ({ surface, sets }: CircleResizeProps) => {
+  const { isDragging: isResizing } = useDrag<SetDefinitionId>({
     surface,
-    INPUT_HANDLER_ID.circleResize,
-    ({ topElement }) => {
+    handlerId: INPUT_HANDLER_ID.circleResize,
+
+    getItem: ({ topElement }) => {
       const identity = setElementIdentity(topElement);
       if (identity?.part !== 'edge') return;
-      return definitions.value.find(({ id }) => id === identity.setId);
+      if (!sets.hasDefinition(identity.setId)) return;
+      return identity.setId;
     },
-    (definition, { at: coords }) => {
-      const { at } = definition.display;
-      const dx = at.x - coords.x;
-      const dy = at.y - coords.y;
-      const distanceFromCenterToCursor = Math.hypot(dx, dy);
-      definition.display.radius = Math.min(
-        Math.max(distanceFromCenterToCursor, MIN_CIRCLE_RADIUS),
-        MAX_CIRCLE_RADIUS,
+
+    // the clamp lives on the mutator, so a decode cannot land somewhere a drag could not
+    onMove: (setId, { at: coords }) => {
+      if (!sets.hasDefinition(setId)) return;
+      const { at } = sets.getDefinition(setId).display;
+      sets.resizeDefinition(
+        setId,
+        Math.hypot(at.x - coords.x, at.y - coords.y),
       );
     },
-  );
+
+    onDrop: (setId) => sets.commitDisplay([setId]),
+  });
 
   return {
     isResizing,

--- a/packages/magic-products/src/sets/composables/useCircleResize.ts
+++ b/packages/magic-products/src/sets/composables/useCircleResize.ts
@@ -23,7 +23,6 @@ export const useCircleResize = ({ surface, sets }: CircleResizeProps) => {
       return identity.setId;
     },
 
-    // the clamp lives on the mutator, so a decode cannot land somewhere a drag could not
     onMove: (setId, { at: coords }) => {
       if (!sets.hasDefinition(setId)) return;
       const { at } = sets.getDefinition(setId).display;

--- a/packages/magic-products/src/sets/composables/useDrag.ts
+++ b/packages/magic-products/src/sets/composables/useDrag.ts
@@ -8,28 +8,44 @@ import { computed, onBeforeUnmount, ref } from 'vue';
 type ActiveDrag<Item> = {
   startingCoords: Coordinate;
   item: Item;
+  /** whether the pointer has actually travelled since the press */
+  moved: boolean;
 };
 
-export const useDrag = <Item>(
-  surface: CanvasSurface,
+type DragOptions<Item> = {
+  surface: CanvasSurface;
   /** what this drag is called by whatever has to take the pointer ahead of it */
-  handlerId: string,
+  handlerId: string;
   /** what the press landed on, or undefined for a press this drag ignores */
-  getItem: (event: ElementMouseEvent) => Item | undefined,
+  getItem: (event: ElementMouseEvent) => Item | undefined;
   /** `at` is where the cursor is now, `diff` how far it moved since the last frame */
-  setItemCoords: (
-    item: Item,
-    cursor: { at: Coordinate; diff: Coordinate },
-  ) => void,
-) => {
+  onMove: (item: Item, cursor: { at: Coordinate; diff: Coordinate }) => void;
+  /**
+   * the gesture settled. skipped for a press that moved nothing, so a click is never
+   * reported as a change to whatever is listening for one
+   */
+  onDrop: (item: Item) => void;
+};
+
+export const useDrag = <Item>({
+  surface,
+  handlerId,
+  getItem,
+  onMove,
+  onDrop,
+}: DragOptions<Item>) => {
   const activeDrag = ref<ActiveDrag<Item>>();
 
   const beginDrag = (elementEvent: ElementMouseEvent) => {
     if (elementEvent.event.button !== MOUSE_BUTTONS.left) return;
     const item = getItem(elementEvent);
-    if (!item) return;
+    if (item === undefined) return;
     // the press carries its own position, so a drag never depends on a mousemove preceding it
-    activeDrag.value = { item, startingCoords: elementEvent.coords };
+    activeDrag.value = {
+      item,
+      startingCoords: elementEvent.coords,
+      moved: false,
+    };
   };
 
   const drag = (event: MouseEvent) => {
@@ -39,12 +55,15 @@ export const useDrag = <Item>(
     const at = surface.toWorldCoordinates(event);
     const diff = { x: at.x - startingCoords.x, y: at.y - startingCoords.y };
 
-    setItemCoords(item, { at, diff });
+    onMove(item, { at, diff });
     activeDrag.value.startingCoords = at;
+    activeDrag.value.moved = true;
   };
 
   const drop = () => {
+    const settled = activeDrag.value;
     activeDrag.value = undefined;
+    if (settled?.moved) onDrop(settled.item);
   };
 
   surface.events.elements.handle('onMouseDown', beginDrag, handlerId);

--- a/packages/magic-products/src/sets/composables/useDrag.ts
+++ b/packages/magic-products/src/sets/composables/useDrag.ts
@@ -8,7 +8,7 @@ import { computed, onBeforeUnmount, ref } from 'vue';
 type ActiveDrag<Item> = {
   startingCoords: Coordinate;
   item: Item;
-  /** whether the pointer has actually travelled since the press */
+  /** true if pointer travelled since the press */
   moved: boolean;
 };
 
@@ -20,10 +20,7 @@ type DragOptions<Item> = {
   getItem: (event: ElementMouseEvent) => Item | undefined;
   /** `at` is where the cursor is now, `diff` how far it moved since the last frame */
   onMove: (item: Item, cursor: { at: Coordinate; diff: Coordinate }) => void;
-  /**
-   * the gesture settled. skipped for a press that moved nothing, so a click is never
-   * reported as a change to whatever is listening for one
-   */
+  /** the gesture settled. skipped for a press that moved nothing */
   onDrop: (item: Item) => void;
 };
 

--- a/packages/magic-products/src/sets/composables/useDrag.ts
+++ b/packages/magic-products/src/sets/composables/useDrag.ts
@@ -8,8 +8,11 @@ import { computed, onBeforeUnmount, ref } from 'vue';
 type ActiveDrag<Item> = {
   startingCoords: Coordinate;
   item: Item;
+<<<<<<< Updated upstream
   /** true if pointer travelled since the press */
   moved: boolean;
+=======
+>>>>>>> Stashed changes
 };
 
 type DragOptions<Item> = {
@@ -20,8 +23,11 @@ type DragOptions<Item> = {
   getItem: (event: ElementMouseEvent) => Item | undefined;
   /** `at` is where the cursor is now, `diff` how far it moved since the last frame */
   onMove: (item: Item, cursor: { at: Coordinate; diff: Coordinate }) => void;
+<<<<<<< Updated upstream
   /** the gesture settled. skipped for a press that moved nothing */
   onDrop: (item: Item) => void;
+=======
+>>>>>>> Stashed changes
 };
 
 export const useDrag = <Item>({
@@ -29,7 +35,6 @@ export const useDrag = <Item>({
   handlerId,
   getItem,
   onMove,
-  onDrop,
 }: DragOptions<Item>) => {
   const activeDrag = ref<ActiveDrag<Item>>();
 
@@ -38,11 +43,7 @@ export const useDrag = <Item>({
     const item = getItem(elementEvent);
     if (item === undefined) return;
     // the press carries its own position, so a drag never depends on a mousemove preceding it
-    activeDrag.value = {
-      item,
-      startingCoords: elementEvent.coords,
-      moved: false,
-    };
+    activeDrag.value = { item, startingCoords: elementEvent.coords };
   };
 
   const drag = (event: MouseEvent) => {
@@ -54,13 +55,10 @@ export const useDrag = <Item>({
 
     onMove(item, { at, diff });
     activeDrag.value.startingCoords = at;
-    activeDrag.value.moved = true;
   };
 
   const drop = () => {
-    const settled = activeDrag.value;
     activeDrag.value = undefined;
-    if (settled?.moved) onDrop(settled.item);
   };
 
   surface.events.elements.handle('onMouseDown', beginDrag, handlerId);

--- a/packages/magic-products/src/sets/composables/useDrag.ts
+++ b/packages/magic-products/src/sets/composables/useDrag.ts
@@ -8,11 +8,6 @@ import { computed, onBeforeUnmount, ref } from 'vue';
 type ActiveDrag<Item> = {
   startingCoords: Coordinate;
   item: Item;
-<<<<<<< Updated upstream
-  /** true if pointer travelled since the press */
-  moved: boolean;
-=======
->>>>>>> Stashed changes
 };
 
 type DragOptions<Item> = {
@@ -23,11 +18,6 @@ type DragOptions<Item> = {
   getItem: (event: ElementMouseEvent) => Item | undefined;
   /** `at` is where the cursor is now, `diff` how far it moved since the last frame */
   onMove: (item: Item, cursor: { at: Coordinate; diff: Coordinate }) => void;
-<<<<<<< Updated upstream
-  /** the gesture settled. skipped for a press that moved nothing */
-  onDrop: (item: Item) => void;
-=======
->>>>>>> Stashed changes
 };
 
 export const useDrag = <Item>({

--- a/packages/magic-products/src/sets/constants.ts
+++ b/packages/magic-products/src/sets/constants.ts
@@ -1,4 +1,4 @@
-import colors from '@core/utils/colors';
+import colors, { type Color } from '@core/utils/colors';
 
 import type { Section } from './types.ts';
 
@@ -22,7 +22,7 @@ export const ANNOTATION_HANDLER_PRIORITY = {
 } as const;
 
 // the palette a query's color is assigned from, in creation order
-export const QUERY_COLORS = [
+export const QUERY_COLORS: Color[] = [
   colors.RED_500,
   colors.BLUE_500,
   colors.EMERALD_500,

--- a/packages/magic-products/src/sets/events.ts
+++ b/packages/magic-products/src/sets/events.ts
@@ -2,14 +2,15 @@ import type { EventMapToEventRegistry } from '@core/events/types';
 
 import type { SetDefinition, SetDefinitionId } from './types.ts';
 
-/** what one add or remove did, never the whole list */
 export type DefinitionsChange = {
+  /** definitions added in this change */
   added: SetDefinition[];
+  /** definitions removed in this change */
   removedIds: SetDefinitionId[];
 };
 
 export type SetDefinitionsEventMap = {
-  /** a set arrived or left, whatever caused it: a double click, a decode, a peer */
+  /** triggered when a set is created or removed */
   onDefinitionsChanged: (change: Readonly<DefinitionsChange>) => void;
   /**
    * a gesture over a circle settled. the boundary history records at and a room writes

--- a/packages/magic-products/src/sets/events.ts
+++ b/packages/magic-products/src/sets/events.ts
@@ -12,18 +12,14 @@ export type DefinitionsChange = {
 export type SetDefinitionsEventMap = {
   /** triggered when a set is created or removed */
   onDefinitionsChanged: (change: Readonly<DefinitionsChange>) => void;
-  /**
-   * a gesture over a circle settled. the boundary history records at and a room writes
-   * at, the same one `onNodePositionsCommitted` draws for a graph. moving and resizing
-   * both land here, since both are the set's display changing
-   */
-  onDisplayCommitted: (setIds: readonly SetDefinitionId[]) => void;
+  /** a set moved or resized */
+  onDisplayChanged: (setIds: readonly SetDefinitionId[]) => void;
 };
 
 export const createSetDefinitionsEventRegistry =
   (): EventMapToEventRegistry<SetDefinitionsEventMap> => ({
     onDefinitionsChanged: new Set(),
-    onDisplayCommitted: new Set(),
+    onDisplayChanged: new Set(),
   });
 
 export type QueriesEventMap = {

--- a/packages/magic-products/src/sets/events.ts
+++ b/packages/magic-products/src/sets/events.ts
@@ -1,0 +1,36 @@
+import type { EventMapToEventRegistry } from '@core/events/types';
+
+import type { SetDefinition, SetDefinitionId } from './types.ts';
+
+/** what one add or remove did, never the whole list */
+export type DefinitionsChange = {
+  added: SetDefinition[];
+  removedIds: SetDefinitionId[];
+};
+
+export type SetDefinitionsEventMap = {
+  /** a set arrived or left, whatever caused it: a double click, a decode, a peer */
+  onDefinitionsChanged: (change: Readonly<DefinitionsChange>) => void;
+  /**
+   * a gesture over a circle settled. the boundary history records at and a room writes
+   * at, the same one `onNodePositionsCommitted` draws for a graph. moving and resizing
+   * both land here, since both are the set's display changing
+   */
+  onDisplayCommitted: (setIds: readonly SetDefinitionId[]) => void;
+};
+
+export const createSetDefinitionsEventRegistry =
+  (): EventMapToEventRegistry<SetDefinitionsEventMap> => ({
+    onDefinitionsChanged: new Set(),
+    onDisplayCommitted: new Set(),
+  });
+
+export type QueriesEventMap = {
+  /** a query arrived, left, or had its latex or visibility rewritten */
+  onQueriesChanged: () => void;
+};
+
+export const createQueriesEventRegistry =
+  (): EventMapToEventRegistry<QueriesEventMap> => ({
+    onQueriesChanged: new Set(),
+  });

--- a/packages/magic-products/src/sets/queries.test.ts
+++ b/packages/magic-products/src/sets/queries.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { QUERY_COLORS } from './constants.ts';
+import { createQueries } from './queries.ts';
+
+const encoded = (latexQueryString: string, hidden = false, color?: string) => ({
+  latexQueryString,
+  hidden,
+  color: color ?? QUERY_COLORS[0],
+});
+
+describe(createQueries, () => {
+  it('opens on one blank query, since the panel always needs a field', () => {
+    const { queries } = createQueries();
+
+    expect(queries.value).toHaveLength(1);
+    expect(queries.value[0].latexQueryString).toBe('');
+  });
+
+  it('reports every way a query is written', () => {
+    const queries = createQueries();
+    const changed = vi.fn();
+    queries.events.subscribe('onQueriesChanged', changed);
+
+    const added = queries.addQuery();
+    added.editor.replace('A \\cup B');
+    added.hidden = true;
+    queries.removeQuery(added.id);
+
+    expect(changed).toHaveBeenCalledTimes(4);
+  });
+
+  it('stays quiet for a write that changed nothing', () => {
+    const queries = createQueries();
+    const [only] = queries.queries.value;
+    only.editor.replace('A');
+    only.hidden = true;
+    const changed = vi.fn();
+    queries.events.subscribe('onQueriesChanged', changed);
+
+    only.editor.replace('A');
+    only.hidden = true;
+    queries.removeQuery('not-a-query');
+
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  describe('the path a decode arrives on', () => {
+    it('restores latex and visibility without a mathfield mounted', () => {
+      const queries = createQueries();
+
+      queries.setAll([encoded('A \\cap B', true), encoded('B')]);
+
+      expect(
+        queries.queries.value.map(({ latexQueryString, hidden }) => ({
+          latexQueryString,
+          hidden,
+        })),
+      ).toEqual([
+        { latexQueryString: 'A \\cap B', hidden: true },
+        { latexQueryString: 'B', hidden: false },
+      ]);
+    });
+
+    it('leaves one blank query behind rather than an empty panel', () => {
+      const queries = createQueries();
+
+      queries.setAll([]);
+
+      expect(queries.queries.value).toHaveLength(1);
+      expect(queries.queries.value[0].latexQueryString).toBe('');
+    });
+
+    it('keeps a color off the palette out of the fill', () => {
+      const queries = createQueries();
+
+      queries.setAll([encoded('A', false, 'javascript:alert(1)')]);
+
+      expect(QUERY_COLORS).toContain(queries.queries.value[0].color);
+    });
+
+    it('hands restored queries ids of their own', () => {
+      const queries = createQueries();
+
+      queries.setAll([encoded('A'), encoded('B')]);
+
+      const [first, second] = queries.queries.value;
+      expect(first.id).not.toBe(second.id);
+      expect(queries.getQuery(second.id).latexQueryString).toBe('B');
+    });
+
+    it('reports restored queries as a change, so they get persisted', () => {
+      const queries = createQueries();
+      const changed = vi.fn();
+      queries.events.subscribe('onQueriesChanged', changed);
+
+      queries.setAll([encoded('A')]);
+
+      expect(changed).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/magic-products/src/sets/queries.ts
+++ b/packages/magic-products/src/sets/queries.ts
@@ -63,10 +63,7 @@ export type Queries = {
   addQuery: () => Query;
   /** Does nothing when no query carries the id. */
   removeQuery: (queryId: QueryId) => void;
-  /**
-   * Makes queries exactly these, in order. An empty list still leaves one blank query,
-   * since the panel is written around always having a field to type into.
-   */
+  /** Makes queries exactly these, in order. */
   setAll: (queries: EncodedQuery[]) => void;
 };
 

--- a/packages/magic-products/src/sets/queries.ts
+++ b/packages/magic-products/src/sets/queries.ts
@@ -1,3 +1,5 @@
+import { createEventHub } from '@core/events/createEventHub';
+import type { ReadonlyEventHub } from '@core/events/createEventHub';
 import { nullThrows } from '@core/utils/assert';
 import type { Color } from '@core/utils/colors';
 import { generateId } from '@core/utils/id';
@@ -6,6 +8,7 @@ import type { MathfieldElement } from '@magic/shared/latex';
 import { type ComputedRef, computed, ref } from 'vue';
 
 import { QUERY_COLORS } from './constants.ts';
+import { type QueriesEventMap, createQueriesEventRegistry } from './events.ts';
 import type { LatexQueryString, QueryId } from './types.ts';
 
 /** Handed the mathfield the query mounted, the one place one is guaranteed to exist. */
@@ -44,14 +47,27 @@ export type Query = {
   readonly editor: QueryEditor;
 };
 
+/** A query stripped to what survives a reload: no id, no editor, no mathfield. */
+export type EncodedQuery = {
+  latexQueryString: LatexQueryString;
+  hidden: boolean;
+  color: Color;
+};
+
 export type Queries = {
   /** Every query in render order. */
   queries: ComputedRef<Query[]>;
+  events: ReadonlyEventHub<QueriesEventMap>;
   /** Throws when no query carries the id. */
   getQuery: (queryId: QueryId) => Query;
   addQuery: () => Query;
   /** Does nothing when no query carries the id. */
   removeQuery: (queryId: QueryId) => void;
+  /**
+   * Makes queries exactly these, in order. An empty list still leaves one blank query,
+   * since the panel is written around always having a field to type into.
+   */
+  setAll: (queries: EncodedQuery[]) => void;
 };
 
 /*
@@ -63,9 +79,13 @@ const nextColor = (queries: Query[]): Color =>
     (color) => !queries.some((query) => query.color === color),
   ) ?? QUERY_COLORS[0];
 
-// takes its color rather than picking one, since only the caller knows the queries already out
-const createQuery = (color: Color): Query => {
-  const latexQueryString = ref<LatexQueryString>('');
+// takes its state rather than defaulting it, since a decode arrives holding all of it
+const createQuery = (
+  { latexQueryString, hidden, color }: EncodedQuery,
+  onChanged: () => void,
+): Query => {
+  const latex = ref<LatexQueryString>(latexQueryString);
+  const isHidden = ref(hidden);
 
   // null until a mathfield renders the query, which is well after the query itself exists
   let commands: QueryEditorCommands | null = null;
@@ -100,27 +120,48 @@ const createQuery = (color: Color): Query => {
     insert: (latexString) => commands?.insert(latexString),
 
     replace: (latexString) => {
-      latexQueryString.value = latexString;
+      if (latex.value === latexString) return;
+      latex.value = latexString;
+      onChanged();
     },
   };
 
   return {
     id: generateId(),
-    hidden: false,
     color,
     editor,
 
     get latexQueryString() {
-      return latexQueryString.value;
+      return latex.value;
+    },
+
+    // an accessor rather than a field, so hiding a query reaches whatever persists it
+    get hidden() {
+      return isHidden.value;
+    },
+    set hidden(value: boolean) {
+      if (isHidden.value === value) return;
+      isHidden.value = value;
+      onChanged();
     },
   };
 };
 
+const BLANK: EncodedQuery = {
+  latexQueryString: '',
+  hidden: false,
+  color: QUERY_COLORS[0],
+};
+
 export const createQueries = (): Queries => {
-  const queries = ref<Query[]>([createQuery(nextColor([]))]);
+  const events = createEventHub(createQueriesEventRegistry());
+  const changed = () => events.emit('onQueriesChanged');
+
+  const queries = ref<Query[]>([createQuery(BLANK, changed)]);
 
   return {
     queries: computed(() => queries.value),
+    events,
 
     getQuery: (queryId) =>
       nullThrows(
@@ -129,13 +170,37 @@ export const createQueries = (): Queries => {
       ),
 
     addQuery: () => {
-      const query = createQuery(nextColor(queries.value));
+      const query = createQuery(
+        { ...BLANK, color: nextColor(queries.value) },
+        changed,
+      );
       queries.value.push(query);
+      changed();
       return query;
     },
 
     removeQuery: (queryId) => {
-      queries.value = queries.value.filter(({ id }) => id !== queryId);
+      const remaining = queries.value.filter(({ id }) => id !== queryId);
+      if (remaining.length === queries.value.length) return;
+      queries.value = remaining;
+      changed();
+    },
+
+    setAll: (incoming) => {
+      const restored: Query[] = [];
+
+      for (const query of incoming) {
+        // a color off the palette would reach the fill straight from a link
+        const color = QUERY_COLORS.includes(query.color)
+          ? query.color
+          : nextColor(restored);
+        restored.push(createQuery({ ...query, color }, changed));
+      }
+
+      if (restored.length === 0) restored.push(createQuery(BLANK, changed));
+
+      queries.value = restored;
+      changed();
     },
   };
 };

--- a/packages/magic-products/src/sets/setDefinitions.test.ts
+++ b/packages/magic-products/src/sets/setDefinitions.test.ts
@@ -1,9 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import { nullThrows } from '@core/utils/assert';
+import { describe, expect, it, vi } from 'vitest';
 
-import { MAX_SETS } from './constants.ts';
-import { createSetDefinitions } from './setDefinitions.ts';
+import {
+  MAX_CIRCLE_RADIUS,
+  MAX_SETS,
+  MIN_CIRCLE_RADIUS,
+  OUTSIDE_ALL_SETS,
+} from './constants.ts';
+import { type DefinitionsChange } from './events.ts';
+import { type SetDefinitions, createSetDefinitions } from './setDefinitions.ts';
+import type { SetDefinition } from './types.ts';
 
 const at = { x: 0, y: 0 };
+
+const definitionOf = (
+  id: string,
+  label: string,
+  display: Partial<SetDefinition['display']> = {},
+): SetDefinition => ({
+  id,
+  label,
+  display: { at: { ...at }, radius: MIN_CIRCLE_RADIUS, ...display },
+});
+
+/** every change the store reported, in order */
+const recordChanges = (sets: SetDefinitions) => {
+  const changes: DefinitionsChange[] = [];
+  sets.events.subscribe('onDefinitionsChanged', (change) =>
+    changes.push({
+      added: [...change.added],
+      removedIds: [...change.removedIds],
+    }),
+  );
+  return changes;
+};
 
 /** a canvas with `count` sets already on it */
 const filledTo = (count: number) => {
@@ -41,5 +71,150 @@ describe(createSetDefinitions, () => {
     );
 
     expect(labels).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+  });
+
+  it('reports what one add and one remove did', () => {
+    const sets = createSetDefinitions();
+    const changes = recordChanges(sets);
+
+    const added = nullThrows(sets.addDefinition(at), 'the canvas was empty');
+    sets.removeDefinition(added.id);
+
+    expect(changes).toEqual([
+      { added: [added], removedIds: [] },
+      { added: [], removedIds: [added.id] },
+    ]);
+  });
+
+  it('says nothing for a remove of an id no set carries', () => {
+    const sets = filledTo(1);
+    const changes = recordChanges(sets);
+
+    sets.remove(['not-a-set']);
+
+    expect(changes).toEqual([]);
+  });
+
+  describe('the paths a decode, an undo and a room arrive on', () => {
+    it('keeps the label it was handed rather than naming the set itself', () => {
+      const sets = createSetDefinitions();
+
+      sets.addDefinitions([definitionOf('from-a-peer', 'D')]);
+
+      // a query naming D has to still mean this set once it lands
+      expect(sets.idByLabel.value['D']).toBe('from-a-peer');
+    });
+
+    it('turns down a duplicate id, a taken label and a reserved one', () => {
+      const sets = createSetDefinitions();
+      sets.addDefinitions([definitionOf('first', 'A')]);
+
+      const admitted = sets.addDefinitions([
+        definitionOf('first', 'B'),
+        definitionOf('second', 'A'),
+        definitionOf('third', OUTSIDE_ALL_SETS.label),
+        definitionOf('fourth', 'B'),
+      ]);
+
+      expect(admitted.map(({ id }) => id)).toEqual(['fourth']);
+    });
+
+    it('stops at the cap rather than overfilling the canvas', () => {
+      const sets = createSetDefinitions();
+
+      sets.setAll(
+        Array.from({ length: MAX_SETS + 4 }, (_, index) =>
+          definitionOf(`set-${index}`, String(index)),
+        ),
+      );
+
+      expect(sets.definitions.value).toHaveLength(MAX_SETS);
+    });
+
+    it('clamps a radius and drops coordinates that are not numbers', () => {
+      const sets = createSetDefinitions();
+
+      sets.setAll([
+        definitionOf('tiny', 'A', { radius: 1 }),
+        definitionOf('huge', 'B', { radius: MAX_CIRCLE_RADIUS * 10 }),
+        definitionOf('nowhere', 'C', { at: { x: NaN, y: Infinity } }),
+      ]);
+
+      const [tiny, huge, nowhere] = sets.definitions.value;
+      expect(tiny.display.radius).toBe(MIN_CIRCLE_RADIUS);
+      expect(huge.display.radius).toBe(MAX_CIRCLE_RADIUS);
+      expect(nowhere.display.at).toEqual({ x: 0, y: 0 });
+    });
+
+    it('reports the diff against what was held, not the whole write', () => {
+      const sets = createSetDefinitions();
+      sets.setAll([definitionOf('kept', 'A'), definitionOf('dropped', 'B')]);
+      const changes = recordChanges(sets);
+
+      sets.setAll([definitionOf('kept', 'A'), definitionOf('arriving', 'C')]);
+
+      expect(changes).toEqual([
+        { added: [definitionOf('arriving', 'C')], removedIds: ['dropped'] },
+      ]);
+    });
+
+    it('commits the display of a set that survived the write, which moved it', () => {
+      const sets = createSetDefinitions();
+      sets.setAll([definitionOf('kept', 'A')]);
+      const committed = vi.fn();
+      sets.events.subscribe('onDisplayCommitted', committed);
+
+      sets.setAll([definitionOf('kept', 'A', { at: { x: 40, y: 40 } })]);
+
+      expect(committed).toHaveBeenCalledWith(['kept']);
+    });
+  });
+
+  describe('display mutators', () => {
+    it('leaves a gesture against a removed set doing nothing', () => {
+      const sets = filledTo(1);
+      const [only] = sets.definitions.value;
+      const committed = vi.fn();
+      sets.events.subscribe('onDisplayCommitted', committed);
+      sets.removeDefinition(only.id);
+
+      sets.moveDefinition(only.id, { x: 10, y: 10 });
+      sets.placeDefinition(only.id, { x: 10, y: 10 });
+      sets.resizeDefinition(only.id, 100);
+      sets.commitDisplay([only.id]);
+
+      expect(committed).not.toHaveBeenCalled();
+    });
+
+    it('clamps a resize the same way a decode is clamped', () => {
+      const sets = filledTo(1);
+      const [only] = sets.definitions.value;
+
+      sets.resizeDefinition(only.id, 1);
+
+      expect(only.display.radius).toBe(MIN_CIRCLE_RADIUS);
+    });
+
+    it('moves by a delta and places at a point', () => {
+      const sets = filledTo(1);
+      const [only] = sets.definitions.value;
+
+      sets.moveDefinition(only.id, { x: 5, y: -5 });
+      expect(only.display.at).toEqual({ x: 5, y: -5 });
+
+      sets.placeDefinition(only.id, { x: 100, y: 100 });
+      expect(only.display.at).toEqual({ x: 100, y: 100 });
+    });
+
+    it('reports the settled gesture once, and only for sets it still holds', () => {
+      const sets = filledTo(2);
+      const [first, second] = sets.definitions.value;
+      const committed = vi.fn();
+      sets.events.subscribe('onDisplayCommitted', committed);
+
+      sets.commitDisplay([first.id, 'not-a-set', second.id]);
+
+      expect(committed).toHaveBeenCalledExactlyOnceWith([first.id, second.id]);
+    });
   });
 });

--- a/packages/magic-products/src/sets/setDefinitions.test.ts
+++ b/packages/magic-products/src/sets/setDefinitions.test.ts
@@ -158,15 +158,15 @@ describe(createSetDefinitions, () => {
       ]);
     });
 
-    it('commits the display of a set that survived the write, which moved it', () => {
+    it('reports the display of a set that survived the write, which moved it', () => {
       const sets = createSetDefinitions();
       sets.setAll([definitionOf('kept', 'A')]);
-      const committed = vi.fn();
-      sets.events.subscribe('onDisplayCommitted', committed);
+      const displayChanged = vi.fn();
+      sets.events.subscribe('onDisplayChanged', displayChanged);
 
       sets.setAll([definitionOf('kept', 'A', { at: { x: 40, y: 40 } })]);
 
-      expect(committed).toHaveBeenCalledWith(['kept']);
+      expect(displayChanged).toHaveBeenCalledWith(['kept']);
     });
   });
 
@@ -174,16 +174,15 @@ describe(createSetDefinitions, () => {
     it('leaves a gesture against a removed set doing nothing', () => {
       const sets = filledTo(1);
       const [only] = sets.definitions.value;
-      const committed = vi.fn();
-      sets.events.subscribe('onDisplayCommitted', committed);
+      const displayChanged = vi.fn();
+      sets.events.subscribe('onDisplayChanged', displayChanged);
       sets.removeDefinition(only.id);
 
       sets.moveDefinition(only.id, { x: 10, y: 10 });
       sets.placeDefinition(only.id, { x: 10, y: 10 });
       sets.resizeDefinition(only.id, 100);
-      sets.commitDisplay([only.id]);
 
-      expect(committed).not.toHaveBeenCalled();
+      expect(displayChanged).not.toHaveBeenCalled();
     });
 
     it('clamps a resize the same way a decode is clamped', () => {
@@ -206,15 +205,18 @@ describe(createSetDefinitions, () => {
       expect(only.display.at).toEqual({ x: 100, y: 100 });
     });
 
-    it('reports the settled gesture once, and only for sets it still holds', () => {
-      const sets = filledTo(2);
-      const [first, second] = sets.definitions.value;
-      const committed = vi.fn();
-      sets.events.subscribe('onDisplayCommitted', committed);
+    it('reports every frame of a gesture, since settling is not the store to know', () => {
+      const sets = filledTo(1);
+      const [only] = sets.definitions.value;
+      const displayChanged = vi.fn();
+      sets.events.subscribe('onDisplayChanged', displayChanged);
 
-      sets.commitDisplay([first.id, 'not-a-set', second.id]);
+      sets.moveDefinition(only.id, { x: 5, y: 0 });
+      sets.moveDefinition(only.id, { x: 5, y: 0 });
+      sets.resizeDefinition(only.id, 100);
 
-      expect(committed).toHaveBeenCalledExactlyOnceWith([first.id, second.id]);
+      expect(displayChanged).toHaveBeenCalledTimes(3);
+      expect(displayChanged).toHaveBeenLastCalledWith([only.id]);
     });
   });
 });

--- a/packages/magic-products/src/sets/setDefinitions.ts
+++ b/packages/magic-products/src/sets/setDefinitions.ts
@@ -1,3 +1,5 @@
+import { createEventHub } from '@core/events/createEventHub';
+import type { ReadonlyEventHub } from '@core/events/createEventHub';
 import type { Coordinate } from '@core/utils/canvas/index';
 import { generateId } from '@core/utils/id';
 
@@ -7,23 +9,98 @@ import { getSetDefinition } from './circleUtils.ts';
 import { useLabelGetter } from './composables/useLabel.ts';
 import {
   DEFAULT_CIRCLE_RADIUS,
+  MAX_CIRCLE_RADIUS,
   MAX_SETS,
+  MIN_CIRCLE_RADIUS,
   OUTSIDE_ALL_SETS,
+  RESERVED_LABELS,
 } from './constants.ts';
+import {
+  type SetDefinitionsEventMap,
+  createSetDefinitionsEventRegistry,
+} from './events.ts';
 import type { SetDefinition, SetDefinitionId, SetLabel } from './types.ts';
 
 export type SetDefinitions = {
   definitions: Ref<SetDefinition[]>;
   // the only authority on what a label typed into a query means, reserved labels included
   idByLabel: ComputedRef<Record<SetLabel, SetDefinitionId>>;
+  events: ReadonlyEventHub<SetDefinitionsEventMap>;
+
   getDefinition: (id: SetDefinitionId) => SetDefinition;
-  /** undefined when the canvas already holds {@link MAX_SETS} */
+  /** false for an id no set carries, which is how a gesture survives a peer's removal */
+  hasDefinition: (id: SetDefinitionId) => boolean;
+
+  /** the authoring path: takes a point and names the set itself */
   addDefinition: (at: Coordinate) => SetDefinition | undefined;
+  /**
+   * adds sets already carrying their id and label, which is what a decode, an undo or a
+   * room hands over. answers with the ones it admitted, see {@link SetDefinitions.setAll}
+   */
+  addDefinitions: (definitions: SetDefinition[]) => SetDefinition[];
   removeDefinition: (id: SetDefinitionId) => void;
+  remove: (ids: SetDefinitionId[]) => void;
+  /** makes definitions exactly these, which is what a decode or a room's copy does */
+  setAll: (definitions: SetDefinition[]) => void;
+
+  /** moves by a delta, the shape a drag reports in */
+  moveDefinition: (id: SetDefinitionId, by: Coordinate) => void;
+  resizeDefinition: (id: SetDefinitionId, radius: number) => void;
+  /** puts a set exactly here, which is what a peer's in flight drag does */
+  placeDefinition: (id: SetDefinitionId, at: Coordinate) => void;
+  /** the gesture settled, see {@link SetDefinitionsEventMap.onDisplayCommitted} */
+  commitDisplay: (setIds: SetDefinitionId[]) => void;
+};
+
+const RESERVED = new Set<SetLabel>(RESERVED_LABELS);
+
+const clampRadius = (radius: number) =>
+  Number.isFinite(radius)
+    ? Math.min(Math.max(radius, MIN_CIRCLE_RADIUS), MAX_CIRCLE_RADIUS)
+    : DEFAULT_CIRCLE_RADIUS;
+
+const finite = (value: number) => (Number.isFinite(value) ? value : 0);
+
+/**
+ * The one gate every bulk path goes through: a link, saved state, an undo and a room all
+ * arrive here. No caller wants an over capacity or duplicate labelled canvas, so the
+ * checks live with the store that has to hold the result rather than at each doorway.
+ */
+const admit = (
+  candidates: SetDefinition[],
+  held: SetDefinition[],
+): SetDefinition[] => {
+  const ids = new Set(held.map(({ id }) => id));
+  const labels = new Set(held.map(({ label }) => label));
+  const admitted: SetDefinition[] = [];
+
+  for (const candidate of candidates) {
+    if (ids.size >= MAX_SETS) break;
+    if (ids.has(candidate.id)) continue;
+    if (labels.has(candidate.label) || RESERVED.has(candidate.label)) continue;
+
+    ids.add(candidate.id);
+    labels.add(candidate.label);
+    admitted.push({
+      id: candidate.id,
+      label: candidate.label,
+      // copied so the store never aliases whatever the caller goes on holding
+      display: {
+        at: {
+          x: finite(candidate.display.at.x),
+          y: finite(candidate.display.at.y),
+        },
+        radius: clampRadius(candidate.display.radius),
+      },
+    });
+  }
+
+  return admitted;
 };
 
 export const createSetDefinitions = (): SetDefinitions => {
   const definitions = ref<SetDefinition[]>([]);
+  const events = createEventHub(createSetDefinitionsEventRegistry());
 
   const nextLabel = useLabelGetter(definitions);
 
@@ -38,30 +115,105 @@ export const createSetDefinitions = (): SetDefinitions => {
 
   const atCapacity = computed(() => definitions.value.length >= MAX_SETS);
 
+  const find = (id: SetDefinitionId) =>
+    definitions.value.find((definition) => definition.id === id);
+
+  const addDefinitions: SetDefinitions['addDefinitions'] = (incoming) => {
+    const added = admit(incoming, definitions.value);
+    if (added.length === 0) return [];
+
+    definitions.value.push(...added);
+    events.emit('onDefinitionsChanged', { added, removedIds: [] });
+    return added;
+  };
+
+  const remove: SetDefinitions['remove'] = (ids) => {
+    const removing = new Set(ids.filter((id) => !!find(id)));
+    if (removing.size === 0) return;
+
+    definitions.value = definitions.value.filter(
+      (definition) => !removing.has(definition.id),
+    );
+    events.emit('onDefinitionsChanged', {
+      added: [],
+      removedIds: [...removing],
+    });
+  };
+
   return {
     definitions,
     idByLabel,
+    events,
 
     getDefinition: (id) => getSetDefinition(definitions.value, id),
+    hasDefinition: (id) => !!find(id),
 
     addDefinition: (at) => {
       if (atCapacity.value) return;
 
-      const definition: SetDefinition = {
-        id: generateId(),
-        label: nextLabel(),
-        // copied so the definition does not alias the live cursor coordinate
-        display: { at: { ...at }, radius: DEFAULT_CIRCLE_RADIUS },
-      };
+      const [added] = addDefinitions([
+        {
+          id: generateId(),
+          label: nextLabel(),
+          display: { at: { ...at }, radius: DEFAULT_CIRCLE_RADIUS },
+        },
+      ]);
 
-      definitions.value.push(definition);
-      return definition;
+      return added;
     },
 
-    removeDefinition: (id) => {
-      definitions.value = definitions.value.filter(
-        (definition) => definition.id !== id,
-      );
+    addDefinitions,
+    removeDefinition: (id) => remove([id]),
+    remove,
+
+    setAll: (incoming) => {
+      const previous = definitions.value;
+      const admitted = admit(incoming, []);
+
+      const previousIds = new Set(previous.map(({ id }) => id));
+      const admittedIds = new Set(admitted.map(({ id }) => id));
+
+      definitions.value = admitted;
+
+      const added = admitted.filter(({ id }) => !previousIds.has(id));
+      const removedIds = [...previousIds].filter((id) => !admittedIds.has(id));
+
+      if (added.length > 0 || removedIds.length > 0) {
+        events.emit('onDefinitionsChanged', { added, removedIds });
+      }
+
+      // a set that survived the write is very likely somewhere else now, and no other
+      // event says so
+      const retained = admitted
+        .filter(({ id }) => previousIds.has(id))
+        .map(({ id }) => id);
+      if (retained.length > 0) events.emit('onDisplayCommitted', retained);
+    },
+
+    moveDefinition: (id, by) => {
+      const { display } = find(id) ?? {};
+      if (!display) return;
+      display.at.x += by.x;
+      display.at.y += by.y;
+    },
+
+    resizeDefinition: (id, radius) => {
+      const definition = find(id);
+      if (!definition) return;
+      definition.display.radius = clampRadius(radius);
+    },
+
+    placeDefinition: (id, at) => {
+      const { display } = find(id) ?? {};
+      if (!display) return;
+      display.at.x = at.x;
+      display.at.y = at.y;
+    },
+
+    commitDisplay: (setIds) => {
+      const committed = setIds.filter((id) => !!find(id));
+      if (committed.length === 0) return;
+      events.emit('onDisplayCommitted', committed);
     },
   };
 };

--- a/packages/magic-products/src/sets/setDefinitions.ts
+++ b/packages/magic-products/src/sets/setDefinitions.ts
@@ -48,8 +48,6 @@ export type SetDefinitions = {
   resizeDefinition: (id: SetDefinitionId, radius: number) => void;
   /** puts a set exactly here, which is what a peer's in flight drag does */
   placeDefinition: (id: SetDefinitionId, at: Coordinate) => void;
-  /** the gesture settled, see {@link SetDefinitionsEventMap.onDisplayCommitted} */
-  commitDisplay: (setIds: SetDefinitionId[]) => void;
 };
 
 const RESERVED = new Set<SetLabel>(RESERVED_LABELS);
@@ -182,12 +180,12 @@ export const createSetDefinitions = (): SetDefinitions => {
         events.emit('onDefinitionsChanged', { added, removedIds });
       }
 
-      // a set that survived the write is very likely somewhere else now, and no other
-      // event says so
+      // a set that survived the write is very likely somewhere else now, and the diff
+      // above says nothing about that
       const retained = admitted
         .filter(({ id }) => previousIds.has(id))
         .map(({ id }) => id);
-      if (retained.length > 0) events.emit('onDisplayCommitted', retained);
+      if (retained.length > 0) events.emit('onDisplayChanged', retained);
     },
 
     moveDefinition: (id, by) => {
@@ -195,12 +193,14 @@ export const createSetDefinitions = (): SetDefinitions => {
       if (!display) return;
       display.at.x += by.x;
       display.at.y += by.y;
+      events.emit('onDisplayChanged', [id]);
     },
 
     resizeDefinition: (id, radius) => {
       const definition = find(id);
       if (!definition) return;
       definition.display.radius = clampRadius(radius);
+      events.emit('onDisplayChanged', [id]);
     },
 
     placeDefinition: (id, at) => {
@@ -208,12 +208,7 @@ export const createSetDefinitions = (): SetDefinitions => {
       if (!display) return;
       display.at.x = at.x;
       display.at.y = at.y;
-    },
-
-    commitDisplay: (setIds) => {
-      const committed = setIds.filter((id) => !!find(id));
-      if (committed.length === 0) return;
-      events.emit('onDisplayCommitted', committed);
+      events.emit('onDisplayChanged', [id]);
     },
   };
 };

--- a/packages/magic-products/src/sets/setDefinitions.ts
+++ b/packages/magic-products/src/sets/setDefinitions.ts
@@ -28,7 +28,7 @@ export type SetDefinitions = {
   events: ReadonlyEventHub<SetDefinitionsEventMap>;
 
   getDefinition: (id: SetDefinitionId) => SetDefinition;
-  /** false for an id no set carries, which is how a gesture survives a peer's removal */
+  /** false for an id no set carries */
   hasDefinition: (id: SetDefinitionId) => boolean;
 
   /** the authoring path: takes a point and names the set itself */

--- a/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
+++ b/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
@@ -37,10 +37,6 @@ export const useSetsShell = (): {
   const sections = useSections(sets.definitions);
   const focus = useSetFocus({ surface });
 
-  /*
-    the gestures stand up here rather than in the view because what a room broadcasts as a
-    drag is driven by them, and that hub has to exist before the shell is built
-  */
   useCircleResize({ surface, sets });
   useCircleDrag({ surface, sets, theme });
 

--- a/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
+++ b/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
@@ -3,6 +3,8 @@ import { canvasCursorOverride } from '@core/themes/index';
 import { ProductControls, Shell, useShell } from '@magic/shared/product';
 
 import QueryPanel from '../components/QueryPanel.vue';
+import { useCircleDrag } from '../composables/useCircleDrag.ts';
+import { useCircleResize } from '../composables/useCircleResize.ts';
 import { useSections } from '../composables/useSections.ts';
 import { useSetFocus } from '../composables/useSetFocus.ts';
 import { useSetsAnnotations } from '../composables/useSetsAnnotations.ts';
@@ -34,6 +36,13 @@ export const useSetsShell = (): {
   const queries = createQueries();
   const sections = useSections(sets.definitions);
   const focus = useSetFocus({ surface });
+
+  /*
+    the gestures stand up here rather than in the view because what a room broadcasts as a
+    drag is driven by them, and that hub has to exist before the shell is built
+  */
+  useCircleResize({ surface, sets });
+  useCircleDrag({ surface, sets, theme });
 
   // no transit, so no: multiplayer, local storage and link sharing
   const product: ProductControls = {

--- a/packages/magic-shared/src/graph-shell/multiplayer/bindGraphToDoc.test.ts
+++ b/packages/magic-shared/src/graph-shell/multiplayer/bindGraphToDoc.test.ts
@@ -460,14 +460,14 @@ describe(bindGraphToDoc, () => {
     };
     author.annotationEvents.emit('onAnnotationsChanged', {
       added: [stroke],
-      removedIds: [],
+      removed: [],
     } as never);
     sync(author.doc, peer.doc);
     expect(peer.annotationsOf().map(({ id }) => id)).toEqual(['stroke-1']);
 
     author.annotationEvents.emit('onAnnotationsChanged', {
       added: [],
-      removedIds: ['stroke-1'],
+      removed: [stroke],
     } as never);
     sync(author.doc, peer.doc);
     expect(peer.annotationsOf()).toEqual([]);

--- a/packages/magic-shared/src/graph-shell/multiplayer/bindGraphToDoc.ts
+++ b/packages/magic-shared/src/graph-shell/multiplayer/bindGraphToDoc.ts
@@ -448,12 +448,12 @@ export const bindGraphToDoc = (
   };
 
   // the settled stroke rather than every point of it, the same boundary node drags use
-  const onAnnotationsChanged = ({ added, removedIds }: AnnotationsChange) => {
+  const onAnnotationsChanged = ({ added, removed }: AnnotationsChange) => {
     intoDoc(() => {
       for (const annotation of added) {
         annotations.set(annotation.id, annotationToDoc(annotation));
       }
-      for (const annotationId of removedIds) annotations.delete(annotationId);
+      for (const annotation of removed) annotations.delete(annotation.id);
     });
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       '@core/components':
         specifier: workspace:*
         version: link:../core-components
+      '@core/events':
+        specifier: workspace:*
+        version: link:../core-events
       '@core/themes':
         specifier: workspace:*
         version: link:../core-themes


### PR DESCRIPTION
Routes every write through the store and gives it two events. Sets and their display are separated from the moment a gesture settles, the same boundary onNodePositionsCommitted draws for a graph, since that is what history records at and what a room writes at.

Authoring and verbatim paths are kept apart: addDefinition names the set itself, addDefinitions and setAll take the id and label as given, which is what a decode, an undo and a peer all need. Every bulk path goes through one admission gate, so the cap, duplicate ids, taken labels and out of range geometry are checked in the place that has to hold the result rather than at each doorway.

A drag now holds the set's id rather than the definition, so a set removed mid gesture leaves the drag moving nothing instead of mutating an orphan, and a press that travelled nowhere no longer reports itself as a change.

The gestures move into useSetsShell because what a room broadcasts as a drag is driven by them, and that hub has to exist before the shell is built.

AnnotationsChange carries the annotations it removed rather than their ids. The engine has them in hand at the removal sites and was throwing them away, leaving anything that needs to reverse a removal to keep a mirror map of its own.

No user visible change.