### PR TITLE
feat(product/sets): persist and share a canvas

### DIFF
--- a/packages/magic-products/package.json
+++ b/packages/magic-products/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/tinycolor2": "catalog:",
+    "lz-string": "^1.5.0",
     "ts-essentials": "^10.2.0"
   }
 }

--- a/packages/magic-products/src/sets/MainView.vue
+++ b/packages/magic-products/src/sets/MainView.vue
@@ -50,7 +50,6 @@
     }
 
     focus.set(definition.id);
-    shell.onboarding?.close();
   };
 
   const deleteFocusedSetDefinitions = () => {

--- a/packages/magic-products/src/sets/components/QueryPanel.vue
+++ b/packages/magic-products/src/sets/components/QueryPanel.vue
@@ -4,7 +4,7 @@
   import VStack from '@magic/shared/VStack';
   import Well from '@magic/shared/Well';
   import { mdiPlus } from '@mdi/js';
-  import { useActiveElement } from '@vueuse/core';
+  import { useActiveElement, useMounted } from '@vueuse/core';
 
   import { computed } from 'vue';
 
@@ -12,6 +12,8 @@
   import type { QueryId } from '../types.ts';
   import InsertSetOpButtons from './InsertSetOpButtons.vue';
   import Query from './Query.vue';
+
+  const mounted = useMounted();
 
   const MAX_NUMBER_OF_QUERIES = 5;
 
@@ -41,7 +43,7 @@
 </script>
 
 <template>
-  <VStack>
+  <VStack v-if="mounted">
     <!-- the ops extend the field they act on, so pressing them must never pull focus out of it -->
     <Well
       v-if="focusedQueryId"

--- a/packages/magic-products/src/sets/sets-shell/transit-compression.test.ts
+++ b/packages/magic-products/src/sets/sets-shell/transit-compression.test.ts
@@ -1,0 +1,131 @@
+import type { Annotation } from '@core/annotations/index';
+import { compressToEncodedURIComponent } from 'lz-string';
+import { describe, expect, it } from 'vitest';
+
+import { QUERY_COLORS } from '../constants.ts';
+import { setsTransitCompression } from './transit-compression.ts';
+import type { SetsTransitPayload } from './transit.ts';
+
+const { compress, decompress } = setsTransitCompression;
+
+const stroke = (id: string): Annotation => ({
+  id,
+  type: 'draw',
+  points: [
+    { x: 0, y: 0 },
+    { x: 10, y: 12 },
+  ],
+  fillColor: '#ff0000',
+  brushWeight: 4,
+});
+
+const payload = (
+  overrides: Partial<SetsTransitPayload> = {},
+): SetsTransitPayload => ({
+  sets: [
+    { label: 'A', x: 10, y: 20, radius: 70 },
+    { label: 'B', x: -30, y: 40, radius: 55 },
+  ],
+  queries: [
+    { latexQueryString: 'A \\cup B', hidden: false, color: QUERY_COLORS[0] },
+    { latexQueryString: 'A \\cap B', hidden: true, color: QUERY_COLORS[2] },
+  ],
+  annotations: [stroke('one')],
+  camera: { panX: 12.34, panY: -56.78, zoom: 1.5 },
+  ...overrides,
+});
+
+const roundTrip = (state: SetsTransitPayload) => decompress(compress(state));
+
+/*
+  a stroke's id is session local: the annotations codec mints new ones on the way back,
+  so a link carries the drawing rather than the identity of each stroke in it
+*/
+const withoutIds = (annotations: Annotation[]) =>
+  annotations.map(({ id, ...stroke }) => stroke);
+
+describe('setsTransitCompression', () => {
+  it('carries a whole canvas back unchanged', () => {
+    const restored = roundTrip(payload());
+    const expected = payload();
+
+    expect(withoutIds(restored.annotations)).toEqual(
+      withoutIds(expected.annotations),
+    );
+    expect({ ...restored, annotations: [] }).toEqual({
+      ...expected,
+      annotations: [],
+    });
+  });
+
+  it('keeps a query readable through every separator the format uses', () => {
+    // a mathfield takes all three, so none of them can be trusted to delimit
+    const latexQueryString = 'A|B;C,D';
+
+    const restored = roundTrip(
+      payload({
+        queries: [{ latexQueryString, hidden: false, color: QUERY_COLORS[1] }],
+      }),
+    );
+
+    expect(restored.queries).toEqual([
+      { latexQueryString, hidden: false, color: QUERY_COLORS[1] },
+    ]);
+  });
+
+  it('leaves the annotations section its own separators', () => {
+    const annotations = [stroke('one'), stroke('two')];
+
+    expect(withoutIds(roundTrip(payload({ annotations })).annotations)).toEqual(
+      withoutIds(annotations),
+    );
+  });
+
+  it('carries an empty canvas', () => {
+    const empty = payload({ sets: [], queries: [], annotations: [] });
+
+    expect(roundTrip(empty)).toEqual(empty);
+  });
+
+  it('rounds geometry to whole units and the camera to two places', () => {
+    const restored = roundTrip(
+      payload({
+        sets: [{ label: 'A', x: 10.6, y: 20.4, radius: 70.5 }],
+        camera: { panX: 1.234_5, panY: 2.999, zoom: 0.333_33 },
+      }),
+    );
+
+    expect(restored.sets).toEqual([{ label: 'A', x: 11, y: 20, radius: 71 }]);
+    expect(restored.camera).toEqual({ panX: 1.23, panY: 3, zoom: 0.33 });
+  });
+
+  it('refuses a payload it cannot read the version of', () => {
+    expect(() => decompress('9|0,0,1|||')).toThrow(/version/);
+  });
+
+  it('refuses a payload cut short', () => {
+    expect(() => decompress('1|0,0,1')).toThrow(/cut short/);
+  });
+
+  it('fits a canvas with annotations inside a link', () => {
+    // the budget link sharing enforces, see MAX_PAYLOAD_CHARS
+    const scribble = (id: string): Annotation => ({
+      ...stroke(id),
+      points: Array.from({ length: 200 }, (_, index) => ({
+        x: index * 1.7,
+        y: Math.sin(index) * 40,
+      })),
+    });
+
+    const busy = payload({
+      annotations: [scribble('one'), scribble('two'), scribble('three')],
+    });
+
+    // the budget is measured on what the url actually carries, see getLinkPayload
+    const asLink = (text: string) => compressToEncodedURIComponent(text).length;
+
+    expect(asLink(compress(busy))).toBeLessThan(2_600);
+    // the same canvas has no chance through the json fallback, which is why this exists
+    expect(asLink(JSON.stringify(busy))).toBeGreaterThan(2_600);
+  });
+});

--- a/packages/magic-products/src/sets/sets-shell/transit-compression.ts
+++ b/packages/magic-products/src/sets/sets-shell/transit-compression.ts
@@ -1,0 +1,124 @@
+import {
+  compressAnnotations,
+  decompressAnnotations,
+} from '@core/annotations/index';
+import { assert } from '@core/utils/assert';
+import type { TransitCompression } from '@magic/shared/product';
+
+import { QUERY_COLORS } from '../constants.ts';
+import type { SetsTransitPayload } from './transit.ts';
+
+const VERSION = '1';
+
+const SECTION = '|';
+const RECORD = ';';
+const FIELD = ',';
+
+/** version, camera, sets, queries, annotations */
+const SECTION_COUNT = 5;
+
+const CAMERA_PRECISION = 100;
+
+const round = (value: number, precision = 1) =>
+  Math.round(value * precision) / precision;
+
+const toNumber = (field: string | undefined) => {
+  const value = Number(field);
+  assert(
+    field && Number.isFinite(value),
+    `sets transit: "${field}" is not a number`,
+  );
+  return value;
+};
+
+/**
+ * leaves the last section whole, so annotations can bring their own separators through
+ * rather than being escaped, which would undo most of what compressing them just saved
+ */
+const splitSections = (text: string) => {
+  const sections: string[] = [];
+
+  let rest = text;
+  for (let index = 0; index < SECTION_COUNT - 1; index++) {
+    const at = rest.indexOf(SECTION);
+    assert(
+      at !== -1,
+      `sets transit: the payload is cut short at section ${index + 1}`,
+    );
+    sections.push(rest.slice(0, at));
+    rest = rest.slice(at + 1);
+  }
+
+  sections.push(rest);
+  return sections;
+};
+
+const records = (section: string) =>
+  section ? section.split(RECORD).map((record) => record.split(FIELD)) : [];
+
+const compress = (payload: SetsTransitPayload) => {
+  const { sets, queries, annotations, camera } = payload;
+
+  const cameraFields = [camera.panX, camera.panY, camera.zoom]
+    .map((value) => round(value, CAMERA_PRECISION))
+    .join(FIELD);
+
+  // labels come from ALPHABET, so they never need escaping
+  const setFields = sets.map(({ label, x, y, radius }) =>
+    [label, round(x), round(y), round(radius)].join(FIELD),
+  );
+
+  const queryFields = queries.map(({ latexQueryString, hidden, color }) => {
+    const colorIndex = QUERY_COLORS.indexOf(color);
+    return [
+      colorIndex === -1 ? 0 : colorIndex,
+      hidden ? 1 : 0,
+      // latex is whatever the user typed, which includes every separator here
+      encodeURIComponent(latexQueryString),
+    ].join(FIELD);
+  });
+
+  return [
+    VERSION,
+    cameraFields,
+    setFields.join(RECORD),
+    queryFields.join(RECORD),
+    compressAnnotations(annotations),
+  ].join(SECTION);
+};
+
+const decompress = (text: string): SetsTransitPayload => {
+  const [version, camera, sets, queries, annotations] = splitSections(text);
+
+  assert(version === VERSION, `sets transit: cannot read version "${version}"`);
+
+  const [panX, panY, zoom] = (camera ?? '').split(FIELD);
+
+  return {
+    sets: records(sets ?? '').map(([label, x, y, radius]) => ({
+      label: label ?? '',
+      x: toNumber(x),
+      y: toNumber(y),
+      radius: toNumber(radius),
+    })),
+
+    queries: records(queries ?? '').map(([colorIndex, hidden, latex]) => ({
+      color: QUERY_COLORS[toNumber(colorIndex)] ?? QUERY_COLORS[0],
+      hidden: hidden === '1',
+      latexQueryString: decodeURIComponent(latex ?? ''),
+    })),
+
+    annotations: decompressAnnotations(annotations ?? ''),
+
+    camera: {
+      panX: toNumber(panX),
+      panY: toNumber(panY),
+      zoom: toNumber(zoom),
+    },
+  };
+};
+
+export const setsTransitCompression: TransitCompression = {
+  compress,
+  decompress,
+};

--- a/packages/magic-products/src/sets/sets-shell/transit.test.ts
+++ b/packages/magic-products/src/sets/sets-shell/transit.test.ts
@@ -1,0 +1,124 @@
+import type { CanvasSurface } from '@canvas/surface/types';
+import type { Annotation, AnnotationsControls } from '@core/annotations/index';
+import { describe, expect, it } from 'vitest';
+
+import { ref } from 'vue';
+
+import { QUERY_COLORS } from '../constants.ts';
+import { createQueries } from '../queries.ts';
+import { createSetDefinitions } from '../setDefinitions.ts';
+import { createSetsTransit } from './transit.ts';
+import type { SetsTransitPayload } from './transit.ts';
+
+/** only the camera, which is all transit asks a surface for */
+const stubSurface = () =>
+  ({
+    camera: { state: { panX: ref(0), panY: ref(0), zoom: ref(1) } },
+  }) as unknown as CanvasSurface;
+
+/** only the two calls transit makes, since the engine itself needs a canvas */
+const stubAnnotations = () => {
+  let held: Annotation[] = [];
+  return {
+    annotations: () => held,
+    setAll: (next: Annotation[]) => {
+      held = next;
+    },
+  } as unknown as AnnotationsControls;
+};
+
+const setup = () => {
+  const sets = createSetDefinitions();
+  const queries = createQueries();
+  const annotations = stubAnnotations();
+  const surface = stubSurface();
+
+  return {
+    sets,
+    queries,
+    annotations,
+    surface,
+    transit: createSetsTransit({ sets, queries, annotations, surface }),
+  };
+};
+
+const stroke: Annotation = {
+  id: 'one',
+  type: 'draw',
+  points: [{ x: 1, y: 2 }],
+  fillColor: '#ff0000',
+  brushWeight: 4,
+};
+
+describe(createSetsTransit, () => {
+  it('carries the whole canvas back into empty stores', () => {
+    const source = setup();
+    const first = source.sets.addDefinition({ x: 10, y: 20 });
+    source.sets.addDefinition({ x: 30, y: 40 });
+    source.queries.queries.value[0].editor.replace('A \\cup B');
+    source.queries.addQuery().hidden = true;
+    source.annotations.setAll([stroke]);
+    source.surface.camera.state.zoom.value = 2;
+
+    const destination = setup();
+    destination.transit.decode(source.transit.encode());
+
+    expect(
+      destination.sets.definitions.value.map(({ label }) => label),
+    ).toEqual(['A', 'B']);
+    expect(destination.sets.definitions.value[0].display.at).toEqual({
+      x: 10,
+      y: 20,
+    });
+    expect(
+      destination.queries.queries.value.map(({ latexQueryString, hidden }) => ({
+        latexQueryString,
+        hidden,
+      })),
+    ).toEqual([
+      { latexQueryString: 'A \\cup B', hidden: false },
+      { latexQueryString: '', hidden: true },
+    ]);
+    expect(destination.annotations.annotations()).toEqual([stroke]);
+    expect(destination.surface.camera.state.zoom.value).toBe(2);
+
+    // ids are minted on the way in, so nothing carries one across the boundary
+    expect(destination.sets.definitions.value[0].id).not.toBe(first?.id);
+  });
+
+  it('replaces what was on the canvas rather than adding to it', () => {
+    const { sets, queries, transit } = setup();
+    sets.addDefinition({ x: 0, y: 0 });
+    sets.addDefinition({ x: 0, y: 0 });
+
+    transit.decode({
+      sets: [{ label: 'C', x: 5, y: 5, radius: 40 }],
+      queries: [],
+      annotations: [],
+      camera: { panX: 0, panY: 0, zoom: 1 },
+    } satisfies SetsTransitPayload);
+
+    expect(sets.definitions.value.map(({ label }) => label)).toEqual(['C']);
+    // the panel is written around always having a field to type into
+    expect(queries.queries.value).toHaveLength(1);
+  });
+
+  it('restores what it can from a payload missing keys', () => {
+    const { sets, surface, transit } = setup();
+
+    transit.decode({ sets: [{ label: 'A', x: 1, y: 2, radius: 40 }] });
+
+    expect(sets.definitions.value).toHaveLength(1);
+    // no camera in the payload leaves the one the user is already looking through
+    expect(surface.camera.state.zoom.value).toBe(1);
+  });
+
+  it('encodes a query palette colour the codec can index', () => {
+    const { queries, transit } = setup();
+    queries.addQuery();
+
+    const { queries: encoded } = transit.encode() as SetsTransitPayload;
+
+    for (const { color } of encoded) expect(QUERY_COLORS).toContain(color);
+  });
+});

--- a/packages/magic-products/src/sets/sets-shell/transit.ts
+++ b/packages/magic-products/src/sets/sets-shell/transit.ts
@@ -1,0 +1,100 @@
+import type { CanvasSurface } from '@canvas/surface/types';
+import type { Annotation, AnnotationsControls } from '@core/annotations/index';
+import { generateId } from '@core/utils/id';
+import type { TransitField } from '@magic/shared/product';
+
+import type { EncodedQuery, Queries } from '../queries.ts';
+import type { SetDefinitions } from '../setDefinitions.ts';
+
+/** a set stripped to what survives a reload, flattened so a codec has nothing to walk */
+export type EncodedSet = {
+  label: string;
+  x: number;
+  y: number;
+  radius: number;
+};
+
+/**
+ * The half of sets a room carries and history steps through: the circles and what has
+ * been drawn over them.
+ */
+export type SetsSharedState = {
+  sets: EncodedSet[];
+  annotations: Annotation[];
+};
+
+/**
+ * Everything sets serializes. The shared half plus the two things that stay on this
+ * device: the queries, which the mathfield owns and replaying would fight, and the
+ * camera, which is where this user happens to be looking.
+ */
+export type SetsTransitPayload = SetsSharedState & {
+  queries: EncodedQuery[];
+  camera: { panX: number; panY: number; zoom: number };
+};
+
+export type SetsTransitParts = {
+  sets: SetDefinitions;
+  queries: Queries;
+  annotations: AnnotationsControls;
+  surface: CanvasSurface;
+};
+
+const encodeSets = (sets: SetDefinitions): EncodedSet[] =>
+  sets.definitions.value.map(({ label, display }) => ({
+    label,
+    x: display.at.x,
+    y: display.at.y,
+    radius: display.radius,
+  }));
+
+/*
+  ids are minted here rather than carried: nothing that outlives a session names a set by
+  id, since a query names it by label. a room is the exception and has its own mapping
+*/
+const decodeSets = (sets: SetDefinitions, encoded: EncodedSet[]) =>
+  sets.setAll(
+    encoded.map(({ label, x, y, radius }) => ({
+      id: generateId(),
+      label,
+      display: { at: { x, y }, radius },
+    })),
+  );
+
+const encodeQueries = (queries: Queries): EncodedQuery[] =>
+  queries.queries.value.map(({ latexQueryString, hidden, color }) => ({
+    latexQueryString,
+    hidden,
+    color,
+  }));
+
+export const createSetsTransit = ({
+  sets,
+  queries,
+  annotations,
+  surface,
+}: SetsTransitParts): TransitField => ({
+  encode: (): SetsTransitPayload => {
+    const { panX, panY, zoom } = surface.camera.state;
+    return {
+      sets: encodeSets(sets),
+      annotations: annotations.annotations(),
+      queries: encodeQueries(queries),
+      camera: { panX: panX.value, panY: panY.value, zoom: zoom.value },
+    };
+  },
+
+  decode: (payload: Partial<SetsTransitPayload>) => {
+    // every write below drops what it cannot use, so a payload missing a key restores
+    // the rest of itself rather than nothing
+    decodeSets(sets, payload.sets ?? []);
+    annotations.setAll(payload.annotations ?? []);
+    queries.setAll(payload.queries ?? []);
+
+    if (!payload.camera) return;
+    const { panX, panY, zoom } = surface.camera.state;
+    panX.value = payload.camera.panX;
+    panY.value = payload.camera.panY;
+    zoom.value = payload.camera.zoom;
+  },
+});

--- a/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
+++ b/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
@@ -15,6 +15,8 @@ import { useCanvasAppearance } from '../theme/useCanvasAppearance.ts';
 import { useSetsTheme } from '../theme/useSetsTheme.ts';
 import { provideSetsState } from './context.ts';
 import { SETS_ONBOARDING } from './onboarding.ts';
+import { setsTransitCompression } from './transit-compression.ts';
+import { createSetsTransit } from './transit.ts';
 import { SetsState } from './types.ts';
 
 /** adapts sets to the shell's controls interface, see {@link useShell} */
@@ -40,10 +42,16 @@ export const useSetsShell = (): {
   useCircleResize({ surface, sets });
   useCircleDrag({ surface, sets, theme });
 
-  // no transit, so no: multiplayer, local storage and link sharing
   const product: ProductControls = {
     surface,
     annotations,
+    transit: {
+      ...createSetsTransit({ sets, queries, annotations, surface }),
+      compression: setsTransitCompression,
+    },
+    // the circles themselves. a resize band is not somewhere to jump back to, and an
+    // annotation is drawn over content rather than being any
+    isContent: ({ id }) => sets.hasDefinition(id),
     onAppearanceChanged: (color) => theme.setActivePreset(color),
     multiplayer: {
       bind: () => {},
@@ -67,7 +75,25 @@ export const useSetsShell = (): {
       },
     ],
     onboarding: SETS_ONBOARDING,
+    // restored state is an answered prompt, the same as a set drawn by hand
+    onSetupCompleted: () => {
+      if (sets.definitions.value.length > 0) shell.onboarding?.close();
+    },
   });
+
+  sets.events.subscribe('onDefinitionsChanged', shell.localStorage.invalidate);
+  sets.events.subscribe('onDisplayChanged', shell.localStorage.invalidate);
+  queries.events.subscribe('onQueriesChanged', shell.localStorage.invalidate);
+  annotations.events.subscribe(
+    'onAnnotationsChanged',
+    shell.localStorage.invalidate,
+  );
+
+  // the first set is the prompt answered. a restore lands before onboarding opens, which
+  // is what onSetupCompleted above is for
+  sets.events.subscribe('onDefinitionsChanged', () =>
+    shell.onboarding?.close(),
+  );
 
   const setsState: SetsState = {
     queries,

--- a/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
+++ b/packages/magic-products/src/sets/sets-shell/useSetsShell.ts
@@ -27,7 +27,6 @@ export const useSetsShell = (): {
   const theme = useSetsTheme();
 
   const surface = useCanvasSurface({
-    // the fallback sentinel is a theme concept, spent here rather than taught to the surface
     canvasCursor: () =>
       canvasCursorOverride(theme._resolveToken('canvas.cursor')),
   });
@@ -49,8 +48,6 @@ export const useSetsShell = (): {
       ...createSetsTransit({ sets, queries, annotations, surface }),
       compression: setsTransitCompression,
     },
-    // the circles themselves. a resize band is not somewhere to jump back to, and an
-    // annotation is drawn over content rather than being any
     isContent: ({ id }) => sets.hasDefinition(id),
     onAppearanceChanged: (color) => theme.setActivePreset(color),
     multiplayer: {
@@ -75,7 +72,6 @@ export const useSetsShell = (): {
       },
     ],
     onboarding: SETS_ONBOARDING,
-    // restored state is an answered prompt, the same as a set drawn by hand
     onSetupCompleted: () => {
       if (sets.definitions.value.length > 0) shell.onboarding?.close();
     },
@@ -89,8 +85,6 @@ export const useSetsShell = (): {
     shell.localStorage.invalidate,
   );
 
-  // the first set is the prompt answered. a restore lands before onboarding opens, which
-  // is what onSetupCompleted above is for
   sets.events.subscribe('onDefinitionsChanged', () =>
     shell.onboarding?.close(),
   );

--- a/packages/magic-shared/src/components/button/classes.ts
+++ b/packages/magic-shared/src/components/button/classes.ts
@@ -1,4 +1,4 @@
 // every property the light half sets needs a dark counterpart, since an unprefixed
 // utility keeps applying in dark mode and would otherwise leak across the themes
 export const buttonClasses =
-  'bg-gray-300 text-gray-900 hover:bg-gray-100 active:bg-gray-100 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700 dark:active:bg-gray-900';
+  'bg-gray-300 text-gray-900 hover:bg-gray-100 active:bg-gray-100 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700 dark:active:bg-gray-700';

--- a/packages/magic-shared/src/components/dropdown/classes.ts
+++ b/packages/magic-shared/src/components/dropdown/classes.ts
@@ -5,4 +5,4 @@ export const menuPanelClasses =
 // menu buttons sit on the panel's own surface, so they drop the button skin's background.
 // the highlight background marks menu position, so a focus ring on top of it is redundant
 export const menuItemClasses =
-  'px-2 bg-transparent dark:bg-transparent dark:hover:bg-gray-900 w-full justify-start focus-visible:ring-0 focus-visible:ring-offset-0';
+  'px-2 bg-transparent dark:bg-transparent dark:hover:bg-gray-900 dark:active:bg-gray-900 w-full justify-start focus-visible:ring-0 focus-visible:ring-offset-0';

--- a/packages/magic-shared/src/product/index.ts
+++ b/packages/magic-shared/src/product/index.ts
@@ -5,6 +5,7 @@ export type {
   Shell,
   ProductControls,
   ShellOptions,
+  TransitCompression,
   TransitField,
 } from './types.ts';
 

--- a/packages/magic-shared/src/product/manifests/index.ts
+++ b/packages/magic-shared/src/product/manifests/index.ts
@@ -5,7 +5,7 @@ export const manifests = {
   sets: {
     id: 'sets',
     multiplayer: false,
-    name: 'Magic Sets',
+    name: 'Magic Set Theory',
     abbreviatedName: 'SET',
     navigation: {
       slug: 'sets',

--- a/packages/magic-shared/src/product/manifests/index.ts
+++ b/packages/magic-shared/src/product/manifests/index.ts
@@ -5,7 +5,7 @@ export const manifests = {
   sets: {
     id: 'sets',
     multiplayer: false,
-    name: 'Magic Set Theory',
+    name: 'Set Theory',
     abbreviatedName: 'SET',
     navigation: {
       slug: 'sets',
@@ -25,7 +25,7 @@ export const manifests = {
   'markov-chains': {
     id: 'markov-chains',
     multiplayer: true,
-    name: 'Magic Markov Chains',
+    name: 'Markov Chains',
     abbreviatedName: 'MKV',
     navigation: {
       slug: 'markov-chains',
@@ -45,7 +45,7 @@ export const manifests = {
   'avl-trees': {
     id: 'avl-trees',
     multiplayer: false,
-    name: 'Magic AVL Trees',
+    name: 'AVL Trees',
     abbreviatedName: 'AVL',
     navigation: {
       slug: 'trees',
@@ -65,7 +65,7 @@ export const manifests = {
   traversals: {
     id: 'traversals',
     multiplayer: true,
-    name: 'Magic Traversals',
+    name: 'Traversals',
     abbreviatedName: 'TRV',
     navigation: {
       slug: 'traversals',
@@ -85,7 +85,7 @@ export const manifests = {
   'path-finding': {
     id: 'path-finding',
     multiplayer: true,
-    name: 'Magic Path Finding',
+    name: 'Path Finding',
     abbreviatedName: 'PTH',
     navigation: {
       slug: 'path',
@@ -105,7 +105,7 @@ export const manifests = {
   'min-spanning-trees': {
     id: 'min-spanning-trees',
     multiplayer: true,
-    name: 'Magic Minimum Spanning Trees',
+    name: 'Minimum Spanning Trees',
     abbreviatedName: 'MST',
     navigation: {
       slug: 'mst',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@types/tinycolor2':
         specifier: 'catalog:'
         version: 1.4.6
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       ts-essentials:
         specifier: ^10.2.0
         version: 10.2.1(typescript@6.0.3)


### PR DESCRIPTION
Gives sets a transit, which is the one field local storage and link sharing are both built on: resolveShellFlags turns them on the moment a product can encode itself, so the chrome, the storage key, the debounce, the share button and the size budget all arrive with it.

What it encodes is one payload split three ways. The shared half is the circles and the annotations, which a room and history will both want. The other two stay on this device: the queries, since the mathfield owns that input state and replaying it would fight the editor, and the camera, which is only where this user happens to be looking.

Ships a compression codec rather than leaning on the JSON fallback, because annotations are the whole story on payload size and JSON has no chance at them. Three ordinary scribbles come to 1.2kB through the codec against a 2.6kB budget, and roughly three times that as JSON. It follows the graph's format closely enough to read side by side, annotations last so their own separators pass through unescaped, and latex percent encoded because a mathfield takes every separator the format uses.

Set ids are minted on decode rather than carried. Nothing that outlives a session names a set by id, since a query names it by label.

Also turns on jump to content, now that there is something worth jumping back to, and closes onboarding over a restored canvas, which otherwise opens its prompt over work that is already there.